### PR TITLE
update init-path behaviour

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -42,7 +42,7 @@ mkdocs-ansible==24.2.1
 mkdocs-autorefs==1.0.1
 mkdocs-gen-files==0.5.0
 mkdocs-htmlproofer-plugin==1.2.0
-mkdocs-material==9.5.13
+mkdocs-material==9.5.17
 mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.8.0
 mkdocs-monorepo-plugin==1.1.0

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -43,7 +43,14 @@ class Init:
 
         :raises CreatorError: if computed collection path is an existing directory or file.
         """
-        col_path = os.path.join(self._init_path, self._namespace, self._collection_name)
+        if self._init_path.endswith("collections/ansible_collections"):
+            col_path = os.path.join(
+                self._init_path,
+                self._namespace,
+                self._collection_name,
+            )
+        else:
+            col_path = self._init_path
 
         self.output.debug(msg=f"final collection path set to {col_path}")
 

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -44,35 +44,33 @@ class Init:
         :raises CreatorError: if computed collection path is an existing directory or file.
         """
         if self._init_path.endswith("collections/ansible_collections"):
-            col_path = os.path.join(
+            self._init_path = os.path.join(
                 self._init_path,
                 self._namespace,
                 self._collection_name,
             )
-        else:
-            col_path = self._init_path
 
-        self.output.debug(msg=f"final collection path set to {col_path}")
+        self.output.debug(msg=f"final collection path set to {self._init_path}")
 
         # check if init_path already exists
-        if os.path.exists(col_path):
-            if os.path.isfile(col_path):
-                msg = f"the path {col_path} already exists, but is a file - aborting"
+        if os.path.exists(self._init_path):
+            if os.path.isfile(self._init_path):
+                msg = f"the path {self._init_path} already exists, but is a file - aborting"
                 raise CreatorError(
                     msg,
                 )
 
             if not self._force:
                 msg = (
-                    f"The directory {col_path} already exists.\n"
+                    f"The directory {self._init_path} already exists.\n"
                     f"You can use --force to re-initialize this directory."
                     f"\nHowever it will delete ALL existing contents in it."
                 )
                 raise CreatorError(msg)
 
             # user requested --force, re-initializing existing directory
-            self.output.warning(f"re-initializing existing directory {col_path}")
-            for root, dirs, files in os.walk(col_path, topdown=True):
+            self.output.warning(f"re-initializing existing directory {self._init_path}")
+            for root, dirs, files in os.walk(self._init_path, topdown=True):
                 for old_dir in dirs:
                     path = os.path.join(root, old_dir)
                     self.output.debug(f"removing tree {old_dir}")
@@ -83,15 +81,15 @@ class Init:
                     os.unlink(path)
 
         # if init_path does not exist, create it
-        if not os.path.exists(col_path):
-            self.output.debug(msg=f"creating new directory at {col_path}")
-            os.makedirs(col_path)
+        if not os.path.exists(self._init_path):
+            self.output.debug(msg=f"creating new directory at {self._init_path}")
+            os.makedirs(self._init_path)
 
         # copy new_collection container to destination, templating files when found
         self.output.debug(msg="started copying collection skeleton to destination")
         copy_container(
             source="new_collection",
-            dest=col_path,
+            dest=self._init_path,
             templar=self._templar,
             template_data={
                 "namespace": self._namespace,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def cli_run(args):
     """execute a command using subprocess."""
     updated_env = os.environ.copy()
     # this helps asserting stdout/stderr
-    updated_env.update({"LINES": "40", "COLUMNS": "500", "TERM": "xterm-256color"})
+    updated_env.update({"LINES": "40", "COLUMNS": "300", "TERM": "xterm-256color"})
     try:
         result = subprocess.run(
             args,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def cli_run(args):
     """execute a command using subprocess."""
     updated_env = os.environ.copy()
     # this helps asserting stdout/stderr
-    updated_env.update({"LINES": "40", "COLUMNS": "300", "TERM": "xterm-256color"})
+    updated_env.update({"LINES": "40", "COLUMNS": "500", "TERM": "xterm-256color"})
     try:
         result = subprocess.run(
             args,

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -97,7 +97,7 @@ def test_run_init_basic(cli, tmp_path):
 
     assert result.returncode != 0
 
-    # sanitize error message (this is due to different line breaks in different CI environments)
+    print(result.stderr)
     assert (
         re.search(
             rf"Error: The directory\s+{final_dest}/testorg/testcol\s+already\s+exists.",

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -76,9 +76,11 @@ def test_run_init_no_input(cli):
 
 
 def test_run_init_basic(cli, tmp_path):
-    cli(f"mkdir -p {tmp_path}/collections/ansible_collections")
+    final_dest = f"{tmp_path}/collections/ansible_collections"
+    cli(f"mkdir -p {final_dest}")
+
     result = cli(
-        f"ansible-creator init testorg.testcol --init-path {tmp_path}/collections/ansible_collections",
+        f"ansible-creator init testorg.testcol --init-path {final_dest}",
     )
     assert result.returncode == 0
 
@@ -90,7 +92,7 @@ def test_run_init_basic(cli, tmp_path):
 
     # fail to override existing collection with force=false (default)
     result = cli(
-        f"ansible-creator init testorg.testcol --init-path {tmp_path}/collections/ansible_collections",
+        f"ansible-creator init testorg.testcol --init-path {final_dest}",
     )
 
     assert result.returncode != 0
@@ -99,6 +101,7 @@ def test_run_init_basic(cli, tmp_path):
         f"{tmp_path}/collections/ansible_collections/testorg/testcol",
         "",
     )
+    print(err_msg)
     assert (
         re.search(
             rf"Error: The directory\s+already\s+exists.",

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -96,7 +96,7 @@ def test_run_init_basic(cli, tmp_path):
     assert result.returncode != 0
     assert (
         re.search(
-            rf"Error: The directory\s+{tmp_path}/collections/ansible_collections/testorg/testcol\s+already exists.",
+            rf"Error: The directory\s+{tmp_path}/collections/ansible_collections/testorg/testcol\s+already(\n|\s)exists.",
             result.stderr,
             flags=re.MULTILINE,
         )

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -97,11 +97,13 @@ def test_run_init_basic(cli, tmp_path):
 
     assert result.returncode != 0
 
-    print(result.stderr.replace("\n", ""))
-
+    mod_stderr = "".join([line.strip() for line in result.stderr.splitlines()])
     assert (
-        f"Error: The directory {final_dest}/testorg/testcol already exists."
-        in result.stderr.replace("\n", " ")
+        re.search(
+            rf"Error:\s*The\s*directory\s*{final_dest}/testorg/testcol\s*already\s*exists",
+            mod_stderr,
+        )
+        is not None
     )
     assert "You can use --force to re-initialize this directory." in result.stderr
     assert "However it will delete ALL existing contents in it." in result.stderr

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -101,7 +101,7 @@ def test_run_init_basic(cli, tmp_path):
 
     assert (
         f"Error: The directory {final_dest}/testorg/testcol already exists."
-        in result.stderr.replace("\n", "")
+        in result.stderr.replace("\n", " ")
     )
     assert "You can use --force to re-initialize this directory." in result.stderr
     assert "However it will delete ALL existing contents in it." in result.stderr

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -97,14 +97,11 @@ def test_run_init_basic(cli, tmp_path):
 
     assert result.returncode != 0
 
-    print(result.stderr)
+    print(result.stderr.replace("\n", ""))
+
     assert (
-        re.search(
-            rf"Error: The directory\s+{final_dest}/testorg/testcol\s+already\s+exists.",
-            result.stderr.replace("\n", ""),
-            flags=re.MULTILINE,
-        )
-        is not None
+        f"Error: The directory {final_dest}/testorg/testcol already exists."
+        in result.stderr.replace("\n", "")
     )
     assert "You can use --force to re-initialize this directory." in result.stderr
     assert "However it will delete ALL existing contents in it." in result.stderr

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -95,11 +95,13 @@ def test_run_init_basic(cli, tmp_path):
 
     assert result.returncode != 0
     # sanitize error message (this is due to different line breaks in different CI environments)
-    err_msg = result.stderr.replace(f"{tmp_path}", "")
-    print(err_msg)
+    err_msg = result.stderr.replace(
+        f"{tmp_path}/collections/ansible_collections/testorg/testcol",
+        "",
+    )
     assert (
         re.search(
-            rf"Error: The directory /collections/ansible_collections/testorg/testcol\s+already\s+exists.",
+            rf"Error: The directory\s+already\s+exists.",
             err_msg,
             flags=re.MULTILINE,
         )

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -96,7 +96,7 @@ def test_run_init_basic(cli, tmp_path):
     assert result.returncode != 0
     assert (
         re.search(
-            rf"Error: The directory\s+{tmp_path}/collections/ansible_collections/testorg/testcol\s+already(\n|\s)exists.",
+            rf"Error: The directory\s+{tmp_path}/collections/ansible_collections/testorg/testcol\s+already\s+exists.",
             result.stderr,
             flags=re.MULTILINE,
         )

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -96,16 +96,12 @@ def test_run_init_basic(cli, tmp_path):
     )
 
     assert result.returncode != 0
+
     # sanitize error message (this is due to different line breaks in different CI environments)
-    err_msg = result.stderr.replace(
-        f"{tmp_path}/collections/ansible_collections/testorg/testcol",
-        "",
-    )
-    print(err_msg)
     assert (
         re.search(
-            rf"Error: The directory\s+already\s+exists.",
-            err_msg,
+            rf"Error: The directory\s+{final_dest}/testorg/testcol\s+already\s+exists.",
+            result.stderr,
             flags=re.MULTILINE,
         )
         is not None

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -92,6 +92,7 @@ def test_run_init_basic(cli, tmp_path):
     result = cli(
         f"ansible-creator init testorg.testcol --init-path {tmp_path}/collections/ansible_collections",
     )
+    print(result.stderr)
     assert result.returncode != 0
     assert (
         re.search(

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -101,7 +101,7 @@ def test_run_init_basic(cli, tmp_path):
     assert (
         re.search(
             rf"Error: The directory\s+{final_dest}/testorg/testcol\s+already\s+exists.",
-            result.stderr,
+            result.stderr.replace("\n", ""),
             flags=re.MULTILINE,
         )
         is not None

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -92,12 +92,15 @@ def test_run_init_basic(cli, tmp_path):
     result = cli(
         f"ansible-creator init testorg.testcol --init-path {tmp_path}/collections/ansible_collections",
     )
-    print(result.stderr)
+
     assert result.returncode != 0
+    # sanitize error message (this is due to different line breaks in different CI environments)
+    err_msg = result.stderr.replace(f"{tmp_path}", "")
+    print(err_msg)
     assert (
         re.search(
-            rf"Error: The directory\s+{tmp_path}/collections/ansible_collections/testorg/testcol\s+already\s+exists.",
-            result.stderr,
+            rf"Error: The directory /collections/ansible_collections/testorg/testcol\s+already\s+exists.",
+            err_msg,
             flags=re.MULTILINE,
         )
         is not None

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -76,7 +76,10 @@ def test_run_init_no_input(cli):
 
 
 def test_run_init_basic(cli, tmp_path):
-    result = cli(f"ansible-creator init testorg.testcol --init-path {tmp_path}")
+    cli(f"mkdir -p {tmp_path}/collections/ansible_collections")
+    result = cli(
+        f"ansible-creator init testorg.testcol --init-path {tmp_path}/collections/ansible_collections",
+    )
     assert result.returncode == 0
 
     # check stdout
@@ -86,11 +89,13 @@ def test_run_init_basic(cli, tmp_path):
     )
 
     # fail to override existing collection with force=false (default)
-    result = cli(f"ansible-creator init testorg.testcol --init-path {tmp_path}")
+    result = cli(
+        f"ansible-creator init testorg.testcol --init-path {tmp_path}/collections/ansible_collections",
+    )
     assert result.returncode != 0
     assert (
         re.search(
-            rf"Error: The directory\s+{tmp_path}/testorg/testcol\s+already exists.",
+            rf"Error: The directory\s+{tmp_path}/collections/ansible_collections/testorg/testcol\s+already exists.",
             result.stderr,
             flags=re.MULTILINE,
         )

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -97,6 +97,7 @@ def test_run_init_basic(cli, tmp_path):
 
     assert result.returncode != 0
 
+    # this is required to handle random line breaks in CI, especially with macos runners
     mod_stderr = "".join([line.strip() for line in result.stderr.splitlines()])
     assert (
         re.search(

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -33,7 +33,7 @@ def cli_args(tmp_path) -> dict:
         "subcommand": "init",
         "verbose": 0,
         "collection": "testorg.testcol",
-        "init_path": tmp_path,
+        "init_path": tmp_path / "testorg" / "testcol",
     }
 
 


### PR DESCRIPTION
--init-path should only create namespace / collection sub directories if init-path ends with collections/ansible_collections

also bumps mkdocs-material to 9.15.7 due to https://github.com/squidfunk/mkdocs-material/blob/master/CHANGELOG#L22