### PR TITLE
fix: replace automation hub workflow secret with release_galaxy secret

### DIFF
--- a/src/ansible_creator/resources/new_collection/.github/workflows/release.yml.j2
+++ b/src/ansible_creator/resources/new_collection/.github/workflows/release.yml.j2
@@ -11,5 +11,5 @@ jobs:
     with:
       environment: release
     secrets:
-      ah_token: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+      ansible_galaxy_api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
 {%- endraw %}

--- a/tests/fixtures/collection/testorg/testcol/.github/workflows/release.yml
+++ b/tests/fixtures/collection/testorg/testcol/.github/workflows/release.yml
@@ -11,4 +11,4 @@ jobs:
     with:
       environment: release
     secrets:
-      ah_token: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+      ansible_galaxy_api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}


### PR DESCRIPTION
Adds the correct workflow secret key for [release_galaxy.yaml](https://github.com/ansible/ansible-content-actions/blob/c2cf076d7518d7dfd46ad90ade5428d651a68f83/.github/workflows/release_galaxy.yaml#L15C7-L15C29); fixing the `release.yaml` workflow script that is generated using `ansible-creator init`.

The [ansible-content-actions](https://github.com/ansible/ansible-content-actions/tree/main/.github/workflows) has two release workflows for automation hub and galaxy. Each uses different secret [key values](https://github.com/ansible/ansible-content-actions/blob/c2cf076d7518d7dfd46ad90ade5428d651a68f83/.github/workflows/release.yaml#L18), `ah_token` and `ansible_galaxy_api_key`.



