### PR TITLE
do not send output args to config class

### DIFF
--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -12,13 +12,7 @@ class Config:
     """The application configuration for ansible-creator."""
 
     creator_version: str
-    json: bool
-    log_append: bool
-    log_file: str
-    log_level: str
-    no_ansi: bool
     subcommand: str
-    verbose: int
 
     collection: str = ""
     force: bool = False

--- a/src/ansible_creator/output.py
+++ b/src/ansible_creator/output.py
@@ -238,7 +238,7 @@ class Output:
             "warning": 0,
         }
         self.term_features = term_features
-        self.logger = logging.getLogger("pip4a")
+        self.logger = logging.getLogger("ansible_creator")
         if log_level != "notset":
             self.logger.setLevel(log_level.upper())
             self.log_to_file = bool(log_file)

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -74,13 +74,7 @@ def test_configuration_class() -> None:
     """Test Config() dataclass post_init."""
     cli_args: dict = {
         "creator_version": "0.0.1",
-        "json": True,
-        "log_append": True,
-        "log_file": "./ansible-creator.log",
-        "log_level": "debug",
-        "no_ansi": False,
         "subcommand": "init",
-        "verbose": 2,
         "collection": "testorg.testcol",
         "init_path": "$HOME",
     }

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -6,7 +6,8 @@ import pytest
 
 from ansible_creator.cli import Cli
 from ansible_creator.config import Config
-from ansible_creator.utils import expand_path
+from ansible_creator.utils import expand_path, TermFeatures
+from ansible_creator.output import Output
 
 
 def test_expand_path() -> None:
@@ -68,6 +69,35 @@ def test_cli_parser(monkeypatch, sysargs, expected) -> None:
     """Test CLI args parsing."""
     monkeypatch.setattr("sys.argv", sysargs)
     assert vars(Cli().parse_args()) == expected
+
+
+def test_cli_init_output(monkeypatch) -> None:
+    sysargs = [
+        "ansible-creator",
+        "init",
+        "testorg.testcol",
+        "--init-path=/home/ansible",
+        "-vvv",
+        "--json",
+        "--no-ansi",
+        "--la=false",
+        "--lf=test.log",
+        "--ll=debug",
+        "--force",
+    ]
+    output = Output(
+        log_append="false",
+        log_file=expand_path("test.log"),
+        log_level="debug",
+        term_features=TermFeatures(color=False, links=False),
+        verbosity=3,
+        display="json",
+    )
+
+    monkeypatch.setattr("sys.argv", sysargs)
+    cli = Cli()
+    cli.init_output()
+    assert vars(cli.output) == vars(output)
 
 
 def test_configuration_class() -> None:

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+import re
 
 from ansible_creator.cli import Cli
 from ansible_creator.config import Config
@@ -16,6 +17,20 @@ def test_expand_path() -> None:
         expand_path("~/$DEV_WORKSPACE/namespace/collection")
         == "/home/ansible/collections/ansible_collections/namespace/collection"
     )
+
+
+def test_configuration_class() -> None:
+    """Test Config() dataclass post_init."""
+    cli_args: dict = {
+        "creator_version": "0.0.1",
+        "subcommand": "init",
+        "collection": "testorg.testcol",
+        "init_path": "$HOME",
+    }
+    app_config = Config(**cli_args)
+    assert app_config.namespace == "testorg"
+    assert app_config.collection_name == "testcol"
+    assert app_config.init_path == "/home/ansible"
 
 
 @pytest.mark.parametrize(
@@ -100,15 +115,22 @@ def test_cli_init_output(monkeypatch) -> None:
     assert vars(cli.output) == vars(output)
 
 
-def test_configuration_class() -> None:
-    """Test Config() dataclass post_init."""
-    cli_args: dict = {
-        "creator_version": "0.0.1",
-        "subcommand": "init",
-        "collection": "testorg.testcol",
-        "init_path": "$HOME",
-    }
-    app_config = Config(**cli_args)
-    assert app_config.namespace == "testorg"
-    assert app_config.collection_name == "testcol"
-    assert app_config.init_path == "/home/ansible"
+def test_cli_main(capsys, tmp_path, monkeypatch) -> None:
+    sysargs = [
+        "ansible-creator",
+        "init",
+        "testns.testcol",
+        f"--init-path={tmp_path}/testns/testcol",
+        "--json",
+        "--force",
+        "-vvv",
+    ]
+
+    monkeypatch.setattr("sys.argv", sysargs)
+    cli = Cli()
+    cli.init_output()
+    cli.run()
+
+    result = capsys.readouterr().out
+    # check stdout
+    assert re.search("collection testns.testcol created", result) is not None

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -25,13 +25,7 @@ def cli_args(tmp_path) -> dict:
     """
     return {
         "creator_version": "0.0.1",
-        "json": True,
-        "log_append": True,
-        "log_file": tmp_path / "ansible-creator.log",
-        "log_level": "debug",
-        "no_ansi": False,
         "subcommand": "init",
-        "verbose": 0,
         "collection": "testorg.testcol",
         "init_path": tmp_path / "testorg" / "testcol",
     }


### PR DESCRIPTION
- We were redundantly passing output related args to Config class. 
- We should instead be passing the output class object (cc @shatakshiiii)