### PR TITLE
Do not fail if `init-path` exists but is empty

### DIFF
--- a/src/ansible_creator/cli.py
+++ b/src/ansible_creator/cli.py
@@ -9,10 +9,10 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
-from ansible_creator.config import Config
-from ansible_creator.exceptions import CreatorError
-from ansible_creator.output import Output
-from ansible_creator.utils import TermFeatures, expand_path
+from .config import Config
+from .exceptions import CreatorError
+from .output import Output
+from .utils import TermFeatures, expand_path
 
 
 try:

--- a/src/ansible_creator/cli.py
+++ b/src/ansible_creator/cli.py
@@ -9,10 +9,10 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
-from .config import Config
-from .exceptions import CreatorError
-from .output import Output
-from .utils import TermFeatures, expand_path
+from ansible_creator.config import Config
+from ansible_creator.exceptions import CreatorError
+from ansible_creator.output import Output
+from ansible_creator.utils import TermFeatures, expand_path
 
 
 try:

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -56,31 +56,35 @@ class Init:
 
         # check if init_path already exists
         if os.path.exists(self._init_path):
+            # init-path exists and is a file
             if os.path.isfile(self._init_path):
                 msg = f"the path {self._init_path} already exists, but is a file - aborting"
                 raise CreatorError(
                     msg,
                 )
+            if os.listdir(self._init_path):
+                # init-path exists and is not empty, but user did not request --force
+                if not self._force:
+                    msg = (
+                        f"The directory {self._init_path} is not empty.\n"
+                        f"You can use --force to re-initialize this directory."
+                        f"\nHowever it will delete ALL existing contents in it."
+                    )
+                    raise CreatorError(msg)
 
-            if not self._force:
-                msg = (
-                    f"The directory {self._init_path} already exists.\n"
-                    f"You can use --force to re-initialize this directory."
-                    f"\nHowever it will delete ALL existing contents in it."
+                # user requested --force, re-initializing existing directory
+                self.output.warning(
+                    f"re-initializing existing directory {self._init_path}",
                 )
-                raise CreatorError(msg)
-
-            # user requested --force, re-initializing existing directory
-            self.output.warning(f"re-initializing existing directory {self._init_path}")
-            for root, dirs, files in os.walk(self._init_path, topdown=True):
-                for old_dir in dirs:
-                    path = os.path.join(root, old_dir)
-                    self.output.debug(f"removing tree {old_dir}")
-                    shutil.rmtree(path)
-                for old_file in files:
-                    path = os.path.join(root, old_file)
-                    self.output.debug(f"removing file {old_file}")
-                    os.unlink(path)
+                for root, dirs, files in os.walk(self._init_path, topdown=True):
+                    for old_dir in dirs:
+                        path = os.path.join(root, old_dir)
+                        self.output.debug(f"removing tree {old_dir}")
+                        shutil.rmtree(path)
+                    for old_file in files:
+                        path = os.path.join(root, old_file)
+                        self.output.debug(f"removing file {old_file}")
+                        os.unlink(path)
 
         # if init_path does not exist, create it
         if not os.path.exists(self._init_path):

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -101,7 +101,7 @@ def test_run_init_basic(cli, tmp_path):
     mod_stderr = "".join([line.strip() for line in result.stderr.splitlines()])
     assert (
         re.search(
-            rf"Error:\s*The\s*directory\s*{final_dest}/testorg/testcol\s*already\s*exists",
+            rf"Error:\s*The\s*directory\s*{final_dest}/testorg/testcol\s*is\s*not\s*empty.",
             mod_stderr,
         )
         is not None

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -57,7 +57,7 @@ def test_run_success_for_collection(
 
     # fail to override existing collection with force=false (default)
     fail_msg = (
-        f"The directory {tmp_path}/testorg/testcol already exists."
+        f"The directory {tmp_path}/testorg/testcol is not empty."
         "\nYou can use --force to re-initialize this directory."
         "\nHowever it will delete ALL existing contents in it."
     )
@@ -107,7 +107,7 @@ def test_run_success_ansible_project(
 
     # fail to override existing ansible-project directory with force=false (default)
     fail_msg = (
-        f"The directory {tmp_path}/new_project already exists."
+        f"The directory {tmp_path}/new_project is not empty."
         "\nYou can use --force to re-initialize this directory."
         "\nHowever it will delete ALL existing contents in it."
     )
@@ -212,12 +212,14 @@ def test_warning(
     )
     init.run()
     result = capsys.readouterr().out
+
+    # this is required to handle random line breaks in CI, especially with macos runners
+    mod_result = "".join([line.strip() for line in result.splitlines()])
     assert (
         re.search(
-            " Warning: The parameters 'scm-org' and 'scm-project' "
-            "have no effect when project\n          is not set to "
-            "ansible-project",
-            result,
+            rf"Warning:\s*The parameters\s*'scm-org'\s*and\s*'scm-project'"
+            rf"\s*have\s*no\s*effect\s*when\s*project\s*is\s*not\s*set\s*to\s*ansible-project",
+            mod_result,
         )
         is not None
     )


### PR DESCRIPTION
With v24.4.0, creator erroneously raises an error even if the final `init-path` exists but is empty. It should only complain when the `init-path` is non-empty and `--force` is disabled.