### PR TITLE
Remove the collection path

### DIFF
--- a/src/ansible_creator/resources/ansible_project/ansible.cfg.j2
+++ b/src/ansible_creator/resources/ansible_project/ansible.cfg.j2
@@ -6,9 +6,6 @@ inventory = inventory/hosts.yml
 host_vars_inventory = inventory/host_vars
 group_vars_inventory = inventory/group_vars
 
-# Specify the collections directory
-collections_path = collections/ansible_collections
-
 # Set the logging verbosity level
 verbosity = 2
 

--- a/tests/fixtures/project/ansible_project/ansible.cfg
+++ b/tests/fixtures/project/ansible_project/ansible.cfg
@@ -6,9 +6,6 @@ inventory = inventory/hosts.yml
 host_vars_inventory = inventory/host_vars
 group_vars_inventory = inventory/group_vars
 
-# Specify the collections directory
-collections_path = collections/ansible_collections
-
 # Set the logging verbosity level
 verbosity = 2
 


### PR DESCRIPTION
After reconsideration of #159, remove the collection path completely

- The playbook adajacent collection will be found automatically
- The use of collection path is incompatible with ADE as it removes the venv site packages directory from the collection search path