### PR TITLE
Don't scaffold pycache or pyc

### DIFF
--- a/src/ansible_creator/constants.py
+++ b/src/ansible_creator/constants.py
@@ -7,4 +7,5 @@ GLOBAL_TEMPLATE_VARS = {
 
 # directory names that will be skipped in any resource
 SKIP_DIRS = ("__pycache__",)
+# file types that will be skipped in any resource
 SKIP_FILES_TYPES = (".pyc",)

--- a/src/ansible_creator/constants.py
+++ b/src/ansible_creator/constants.py
@@ -4,3 +4,7 @@ GLOBAL_TEMPLATE_VARS = {
     "DEV_CONTAINER_IMAGE": "ghcr.io/ansible/community-ansible-dev-tools:latest",
     "DEV_FILE_IMAGE": "ghcr.io/ansible/ansible-workspace-env-reference:latest",
 }
+
+# directory names that will be skipped in any resource
+SKIP_DIRS = ("__pycache__",)
+SKIP_FILES_TYPES = (".pyc",)

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from ansible_creator.constants import GLOBAL_TEMPLATE_VARS
+from ansible_creator.constants import GLOBAL_TEMPLATE_VARS, SKIP_DIRS, SKIP_FILES_TYPES
 
 
 if TYPE_CHECKING:
@@ -104,6 +104,8 @@ class Copier:
                     dest_path = dest_path.replace(key, template_data.get(val, ""))
 
             if obj.is_dir():
+                if obj.name in SKIP_DIRS:
+                    continue
                 if not os.path.exists(dest_path):
                     os.makedirs(dest_path)
 
@@ -114,6 +116,8 @@ class Copier:
                 )
 
             elif obj.is_file():
+                if obj.name.split(".")[-1] in SKIP_FILES_TYPES:
+                    continue
                 if obj.name == "__meta__.yml":
                     continue
                 # remove .j2 suffix at destination


### PR DESCRIPTION
Related #164 

When ansible-creator is installed by pip, some pycache and pyc files are created in the collection unit test directory:

```
(venv) m910x ➜  test tree venv/lib/python3.12/site-packages/ansible_creator/resources/new_collection/tests/unit/                                   
venv/lib/python3.12/site-packages/ansible_creator/resources/new_collection/tests/unit/
├── __pycache__
│   └── test_basic.cpython-312.pyc
└── test_basic.py

```
These cause a traceback when scaffolding:

```
test ansible-creator init --project collection collection=a.b --init-path /tmp/foo --force      
 Warning: re-initializing existing directory /tmp/foo
Traceback (most recent call last):
  File "/tmp/test/venv/bin/ansible-creator", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/cli.py", line 211, in main
    cli.run()
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/cli.py", line 199, in run
    subcommand(config=Config(**self.args, output=self.output)).run()
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/subcommands/init.py", line 114, in run
    copier.copy_containers()
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/utils.py", line 199, in copy_containers
    self._per_container()
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/utils.py", line 185, in _per_container
    self._recursive_copy(
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/utils.py", line 111, in _recursive_copy
    self._recursive_copy(
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/utils.py", line 111, in _recursive_copy
    self._recursive_copy(
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/utils.py", line 111, in _recursive_copy
    self._recursive_copy(
  File "/tmp/test/venv/lib64/python3.12/site-packages/ansible_creator/utils.py", line 128, in _recursive_copy
    content = obj.read_text(encoding="utf-8")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/pathlib.py", line 1028, in read_text
    return f.read()
           ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcb in position 0: invalid continuation byte
```

Not caught in our tests because it's not run from an installed package.

Found during adt tests for server b/c the server was throwing a 500

https://github.com/ansible/ansible-dev-tools/actions/runs/8929768888

