### PR TITLE
Remediate ruff errors related to not using `pathlib.Path`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           - pytest
         args:
           - src
-          - --python-version=3.10
+          - --python-version=3.12
         pass_filenames: false
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           - pytest
         args:
           - src
-          - --python-version=3.12
+          - --python-version=3.10
         pass_filenames: false
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,19 +81,9 @@ disable = [
 
 [tool.ruff]
 builtins = ["__"]
-exclude = ['tests']
+exclude = ["_version.py", "tests"]
 fix = true
 ignore = [
-  "C901",
-  "PTH100",
-  "PTH103",
-  "PTH108",
-  "PTH110",
-  "PTH111",
-  "PTH113",
-  "PTH118",
-  "PTH123",
-  "TRY400"
 ]
 line-length = 100
 select = ["ALL"]

--- a/src/ansible_creator/cli.py
+++ b/src/ansible_creator/cli.py
@@ -43,7 +43,7 @@ class Cli:
 
         self.output = Output(
             log_append=self.args.pop("log_append"),
-            log_file=expand_path(self.args.pop("log_file")),
+            log_file=str(expand_path(self.args.pop("log_file"))),
             log_level=self.args.pop("log_level"),
             term_features=self.term_features,
             verbosity=self.args.pop("verbose"),

--- a/src/ansible_creator/output.py
+++ b/src/ansible_creator/output.py
@@ -245,7 +245,6 @@ class Output:
         self.logger = logging.getLogger("ansible_creator")
         if log_level != "notset":
             self.logger.setLevel(log_level.upper())
-            self.log_to_file = bool(log_file)
             log_file_path = Path(log_file)
             if log_file_path.exists() and log_append == "false":
                 log_file_path.unlink()

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -24,7 +24,9 @@ def test_configuration_class(output: Output) -> None:
     app_config = Config(**cli_args)
     assert app_config.namespace == "testorg"
     assert app_config.collection_name == "testcol"
-    assert app_config.init_path == Path("/home/ansible")
+    linux_path = Path("/home/ansible")
+    mac_os_path = Path("System/Volumes/Data/home/ansible")
+    assert app_config.init_path in [linux_path, mac_os_path]
 
 
 @pytest.mark.parametrize(

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -25,7 +25,7 @@ def test_configuration_class(output: Output) -> None:
     assert app_config.namespace == "testorg"
     assert app_config.collection_name == "testcol"
     linux_path = Path("/home/ansible")
-    mac_os_path = Path("System/Volumes/Data/home/ansible")
+    mac_os_path = Path("/System/Volumes/Data/home/ansible")
     assert app_config.init_path in [linux_path, mac_os_path]
 
 

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -12,12 +12,6 @@ from ansible_creator.utils import expand_path, TermFeatures
 from ansible_creator.output import Output
 
 
-def test_expand_path() -> None:
-    """Test expand_path utils."""
-    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == Path(
-        "/home/ansible/collections/ansible_collections/namespace/collection",
-    )
-
 
 def test_configuration_class(output: Output) -> None:
     """Test Config() dataclass post_init."""

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -14,9 +14,8 @@ from ansible_creator.output import Output
 
 def test_expand_path() -> None:
     """Test expand_path utils."""
-    assert (
-        expand_path("~/$DEV_WORKSPACE/namespace/collection")
-        == "/home/ansible/collections/ansible_collections/namespace/collection"
+    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == Path(
+        "/home/ansible/collections/ansible_collections/namespace/collection",
     )
 
 
@@ -32,7 +31,7 @@ def test_configuration_class(output: Output) -> None:
     app_config = Config(**cli_args)
     assert app_config.namespace == "testorg"
     assert app_config.collection_name == "testcol"
-    assert app_config.init_path == "/home/ansible"
+    assert app_config.init_path == Path("/home/ansible")
 
 
 @pytest.mark.parametrize(
@@ -184,7 +183,7 @@ def test_cli_init_output(monkeypatch) -> None:
     ]
     output = Output(
         log_append="false",
-        log_file=expand_path("test.log"),
+        log_file=str(expand_path("test.log")),
         log_level="debug",
         term_features=TermFeatures(color=False, links=False),
         verbosity=3,

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -12,7 +12,6 @@ from ansible_creator.utils import expand_path, TermFeatures
 from ansible_creator.output import Output
 
 
-
 def test_configuration_class(output: Output) -> None:
     """Test Config() dataclass post_init."""
     cli_args: dict = {

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+
 import re
+import shutil
 
 from filecmp import dircmp
 from pathlib import Path
@@ -252,15 +254,13 @@ def test_delete_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         ),
     )
 
-    def rmtree(path: Path) -> None:
-        raise OSError("Failed to delete directory")
+    err = "Test thrown error"
 
-    import shutil
+    def rmtree(path: Path) -> None:
+        raise OSError(err)
 
     monkeypatch.setattr(shutil, "rmtree", rmtree)
 
-    fail_msg = "Failed to delete directory"
-
-    with pytest.raises(CreatorError, match=fail_msg) as exc_info:
+    with pytest.raises(CreatorError, match=err) as exc_info:
         init.run()
     assert "failed to remove existing directory" in str(exc_info.value)

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -264,3 +264,34 @@ def test_delete_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     with pytest.raises(CreatorError, match=err) as exc_info:
         init.run()
     assert "failed to remove existing directory" in str(exc_info.value)
+
+
+def test_is_file_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test a file dest fails gracefully.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory path.
+    """
+    file = tmp_path / "file.txt"
+    file.touch()
+    init = Init(
+        Config(
+            creator_version="0.0.1",
+            force=True,
+            subcommand="init",
+            collection="testorg.testcol",
+            init_path=str(file),
+            output=Output(
+                log_file=str(tmp_path / "log.log"),
+                log_level="DEBUG",
+                log_append="false",
+                term_features=TermFeatures(color=False, links=False),
+                verbosity=0,
+            ),
+        ),
+    )
+
+    with pytest.raises(CreatorError) as exc_info:
+        init.run()
+    assert "but is a file" in str(exc_info.value)

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -10,7 +10,7 @@ def test_expand_path() -> None:
     home = Path.home().resolve()
     expected = home / "collections/ansible_collections/namespace/collection"
     assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == expected
-    assert expand_path("~") == Path.home()
+    assert expand_path("~") == home
     assert expand_path("foo") == Path.cwd() / "foo"
-    assert expand_path("$HOME") == Path.home()
-    assert expand_path("~/$HOME") == Path(str(Path.home()) + str(Path.home()))
+    assert expand_path("$HOME") == home
+    assert expand_path("~/$HOME") == Path(f"{home}/{home}")

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -7,8 +7,10 @@ from ansible_creator.utils import expand_path
 
 def test_expand_path() -> None:
     """Test expand_path utils."""
-    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == Path(
-        "/home/ansible/collections/ansible_collections/namespace/collection",
+    assert (
+        expand_path("~/$DEV_WORKSPACE/namespace/collection")
+        == Path.home()
+        / "/home/ansible/collections/ansible_collections/namespace/collection"
     )
     assert expand_path("~") == Path.home()
     assert expand_path("foo") == Path.cwd() / "foo"

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -1,0 +1,13 @@
+"""Test the utils module."""
+
+from pathlib import Path
+
+from ansible_creator.utils import expand_path
+
+
+def test_expand_path() -> None:
+    """Test expand_path."""
+    assert expand_path("~") == Path.home()
+    assert expand_path("foo") == Path.cwd() / "foo"
+    assert expand_path("$HOME") == Path.home()
+    assert expand_path("~/$HOME") == Path(str(Path.home()) + str(Path.home()))

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -6,7 +6,10 @@ from ansible_creator.utils import expand_path
 
 
 def test_expand_path() -> None:
-    """Test expand_path."""
+    """Test expand_path utils."""
+    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == Path(
+        "/home/ansible/collections/ansible_collections/namespace/collection",
+    )
     assert expand_path("~") == Path.home()
     assert expand_path("foo") == Path.cwd() / "foo"
     assert expand_path("$HOME") == Path.home()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -7,7 +7,7 @@ from ansible_creator.utils import expand_path
 
 def test_expand_path() -> None:
     """Test expand_path utils."""
-    home = Path.home()
+    home = Path.home().resolve()
     expected = home / "collections/ansible_collections/namespace/collection"
     assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == expected
     assert expand_path("~") == Path.home()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -9,8 +9,7 @@ def test_expand_path() -> None:
     """Test expand_path utils."""
     assert (
         expand_path("~/$DEV_WORKSPACE/namespace/collection")
-        == Path.home()
-        / "/home/ansible/collections/ansible_collections/namespace/collection"
+        == (Path.home() / "/home/ansible/collections/ansible_collections/namespace/collection")
     )
     assert expand_path("~") == Path.home()
     assert expand_path("foo") == Path.cwd() / "foo"

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -8,8 +8,7 @@ from ansible_creator.utils import expand_path
 def test_expand_path() -> None:
     """Test expand_path utils."""
     assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == (
-        Path.home()
-        / "/home/ansible/collections/ansible_collections/namespace/collection"
+        Path.home() / "/collections/ansible_collections/namespace/collection"
     )
     assert expand_path("~") == Path.home()
     assert expand_path("foo") == Path.cwd() / "foo"

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -13,4 +13,4 @@ def test_expand_path() -> None:
     assert expand_path("~") == home
     assert expand_path("foo") == Path.cwd() / "foo"
     assert expand_path("$HOME") == home
-    assert expand_path("~/$HOME") == Path(f"{home}/{home}")
+    assert expand_path("~/$HOME") == Path(f"{home}/{Path.home()}")

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -7,9 +7,9 @@ from ansible_creator.utils import expand_path
 
 def test_expand_path() -> None:
     """Test expand_path utils."""
-    assert (
-        expand_path("~/$DEV_WORKSPACE/namespace/collection")
-        == (Path.home() / "/home/ansible/collections/ansible_collections/namespace/collection")
+    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == (
+        Path.home()
+        / "/home/ansible/collections/ansible_collections/namespace/collection"
     )
     assert expand_path("~") == Path.home()
     assert expand_path("foo") == Path.cwd() / "foo"

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -7,9 +7,9 @@ from ansible_creator.utils import expand_path
 
 def test_expand_path() -> None:
     """Test expand_path utils."""
-    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == (
-        Path.home() / "/collections/ansible_collections/namespace/collection"
-    )
+    home = Path.home()
+    expected = home / "collections/ansible_collections/namespace/collection"
+    assert expand_path("~/$DEV_WORKSPACE/namespace/collection") == expected
     assert expand_path("~") == Path.home()
     assert expand_path("foo") == Path.cwd() / "foo"
     assert expand_path("$HOME") == Path.home()


### PR DESCRIPTION
- Switch to pathlib Paths when possible
- Remove exccluded PTH ruff errors
- Exclude _version.py since it's generated
- Changes types as needed
- Move the expand path test into a new test_utils file 