### PR TITLE
Update precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - prettier-plugin-toml
           - prettier-plugin-sort-json
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
+  - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
       - id: black
@@ -107,17 +107,14 @@ repos:
           - src
           - --python-version=3.10
         pass_filenames: false
+
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1
     hooks:
       - id: pip-compile
         name: deps
         alias: deps
-        always_run: true
-        entry: pip-compile -q --no-annotate --output-file=.config/constraints.txt pyproject.toml --all-extras --strip-extras
-        files: ^.config\/.*(requirements|constraints).*$
-        language: python
-        language_version: "3.10" # minimal we support officially
-        pass_filenames: false
-        additional_dependencies:
-          - pip>=22.3.1
+        stages: [manual]
+        entry: pip-compile .config/requirements.in --upgrade --all-extras --no-annotate --strip-extras --output-file=.config/constraints.txt pyproject.toml
+        files: ^.config\/.*requirements.*$
+        language_version: "3.10" # minimal we support official

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,60 +76,275 @@ module = ["pytest_ansible.molecule"]
 
 [tool.pylint]
 
-[tool.pylint.MASTER]
-ignore-patterns = 'test_*'
-
 [tool.pylint.format]
 max-line-length = 100
 
 [tool.pylint.master]
 good-names = "i,j,k,ex,Run,_,f,fh"
 ignore = [
-  "_version.py" # built by setuptools_scm
+  "_version.py", # generated
+  "test_integration.py" # will have a pytest-ansible import error
 ]
 jobs = 0
 no-docstring-rgx = "__.*__"
 
 [tool.pylint.messages_control]
 disable = [
-  "C0114", # missing-module-docstring
+  "unknown-option-value",
+  # https://gist.github.com/cidrblock/ec3412bacfeb34dbc2d334c1d53bef83
+  "C0103", # invalid-name / ruff N815
+  "C0105", # typevar-name-incorrect-variance / ruff PLC0105
+  "C0112", # empty-docstring / ruff D419
+  "C0113", # unneeded-not / ruff SIM208
+  "C0114", # missing-module-docstring / ruff D100
+  "C0115", # missing-class-docstring / ruff D101
+  "C0116", # missing-function-docstring / ruff D103
+  "C0121", # singleton-comparison / ruff PLC0121
+  "C0123", # unidiomatic-typecheck / ruff E721
+  "C0131", # typevar-double-variance / ruff PLC0131
+  "C0132", # typevar-name-mismatch / ruff PLC0132
+  "C0198", # bad-docstring-quotes / ruff Q002
+  "C0199", # docstring-first-line-empty / ruff D210
+  "C0201", # consider-iterating-dictionary / ruff SIM118
+  "C0202", # bad-classmethod-argument / ruff PLC0202
+  "C0205", # single-string-used-for-slots / ruff PLC0205
+  "C0208", # use-sequence-for-iteration / ruff PLC0208
+  "C0301", # line-too-long / ruff E501
+  "C0303", # trailing-whitespace / ruff W291
+  "C0304", # missing-final-newline / ruff W292
+  "C0321", # multiple-statements / ruff PLC0321
+  "C0410", # multiple-imports / ruff E401
+  "C0411", # wrong-import-order / ruff I001
+  "C0412", # ungrouped-imports / ruff I001
+  "C0413", # wrong-import-position / ruff E402
+  "C0414", # useless-import-alias / ruff PLC0414
+  "C0415", # import-outside-toplevel / ruff PLC0415
+  "C0501", # consider-using-any-or-all / ruff PLC0501
+  "C1901", # compare-to-empty-string / ruff PLC1901
+  "C2201", # misplaced-comparison-constant / ruff SIM300
+  "C2401", # non-ascii-name / ruff PLC2401
+  "C2403", # non-ascii-module-import / ruff PLC2403
+  "C2701", # import-private-name / ruff PLC2701
+  "C2801", # unnecessary-dunder-call / ruff PLC2801
+  "C3001", # unnecessary-lambda-assignment / ruff E731
+  "C3002", # unnecessary-direct-lambda-call / ruff PLC3002
+  "E0001", # syntax-error / ruff E999
+  "E0100", # init-is-generator / ruff PLE0100
+  "E0101", # return-in-init / ruff PLE0101
+  "E0102", # function-redefined / ruff F811
+  "E0103", # not-in-loop / ruff PLE0103
+  "E0104", # return-outside-function / ruff F706
+  "E0105", # yield-outside-function / ruff F704
+  "E0107", # nonexistent-operator / ruff B002
+  "E0112", # too-many-star-expressions / ruff F622
+  "E0115", # nonlocal-and-global / ruff PLE0115
+  "E0116", # continue-in-finally / ruff PLE0116
+  "E0117", # nonlocal-without-binding / ruff PLE0117
+  "E0118", # used-prior-global-declaration / ruff PLE0118
+  "E0211", # no-method-argument / ruff N805
+  "E0213", # no-self-argument / ruff N805
+  "E0237", # assigning-non-slot / ruff PLE0237
+  "E0241", # duplicate-bases / ruff PLE0241
+  "E0302", # unexpected-special-method-signature / ruff PLE0302
+  "E0303", # invalid-length-returned / ruff PLE0303
+  "E0304", # invalid-bool-returned / ruff PLE0304
+  "E0305", # invalid-index-returned / ruff PLE0305
+  "E0308", # invalid-bytes-returned / ruff PLE0308
+  "E0309", # invalid-hash-returned / ruff PLE0309
+  "E0402", # relative-beyond-top-level / ruff TID252
   "E0602", # undefined-variable / ruff F821
-  "R0913",
+  "E0603", # undefined-all-variable / ruff F822
+  "E0604", # invalid-all-object / ruff PLE0604
+  "E0605", # invalid-all-format / ruff PLE0605
+  "E0643", # potential-index-error / ruff PLE0643
+  "E0704", # misplaced-bare-raise / ruff PLE0704
+  "E0711", # notimplemented-raised / ruff F901
+  "E1132", # repeated-keyword / ruff PLE1132
+  "E1142", # await-outside-async / ruff PLE1142
+  "E1205", # logging-too-many-args / ruff PLE1205
+  "E1206", # logging-too-few-args / ruff PLE1206
+  "E1300", # bad-format-character / ruff PLE1300
+  "E1301", # truncated-format-string / ruff F501
+  "E1302", # mixed-format-string / ruff F506
+  "E1303", # format-needs-mapping / ruff F502
+  "E1304", # missing-format-string-key / ruff F524
+  "E1305", # too-many-format-args / ruff F522
+  "E1306", # too-few-format-args / ruff F524
+  "E1307", # bad-string-format-type / ruff PLE1307
+  "E1310", # bad-str-strip-call / ruff PLE1310
+  "E1519", # singledispatch-method / ruff PLE1519
+  "E1520", # singledispatchmethod-function / ruff PLE5120
+  "E1700", # yield-inside-async-function / ruff PLE1700
+  "E2502", # bidirectional-unicode / ruff PLE2502
+  "E2510", # invalid-character-backspace / ruff PLE2510
+  "E2512", # invalid-character-sub / ruff PLE2512
+  "E2513", # invalid-character-esc / ruff PLE2513
+  "E2514", # invalid-character-nul / ruff PLE2514
+  "E2515", # invalid-character-zero-width-space / ruff PLE2515
+  "E4703", # modified-iterating-set / ruff PLE4703
+  "R0123", # literal-comparison / ruff F632
+  "R0124", # comparison-with-itself / ruff PLR0124
+  "R0133", # comparison-of-constants / ruff PLR0133
+  "R0202", # no-classmethod-decorator / ruff PLR0202
+  "R0203", # no-staticmethod-decorator / ruff PLR0203
+  "R0205", # useless-object-inheritance / ruff UP004
+  "R0206", # property-with-parameters / ruff PLR0206
+  "R0904", # too-many-public-methods / ruff PLR0904
+  "R0911", # too-many-return-statements / ruff PLR0911
+  "R0912", # too-many-branches / ruff PLR0912
+  "R0913", # too-many-arguments / ruff PLR0913
+  "R0914", # too-many-locals / ruff PLR0914
+  "R0915", # too-many-statements / ruff PLR0915
+  "R0916", # too-many-boolean-expressions / ruff PLR0916
+  "R1260", # too-complex / ruff C901
+  "R1701", # consider-merging-isinstance / ruff PLR1701
+  "R1702", # too-many-nested-blocks / ruff PLR1702
+  "R1703", # simplifiable-if-statement / ruff SIM108
+  "R1704", # redefined-argument-from-local / ruff PLR1704
+  "R1705", # no-else-return / ruff RET505
+  "R1706", # consider-using-ternary / ruff PLR1706
+  "R1707", # trailing-comma-tuple / ruff COM818
+  "R1710", # inconsistent-return-statements / ruff PLR1710
+  "R1711", # useless-return / ruff PLR1711
+  "R1714", # consider-using-in / ruff PLR1714
+  "R1715", # consider-using-get / ruff SIM401
+  "R1717", # consider-using-dict-comprehension / ruff C402
+  "R1718", # consider-using-set-comprehension / ruff C401
+  "R1719", # simplifiable-if-expression / ruff PLR1719
+  "R1720", # no-else-raise / ruff RET506
+  "R1721", # unnecessary-comprehension / ruff C416
+  "R1722", # consider-using-sys-exit / ruff PLR1722
+  "R1723", # no-else-break / ruff RET508
+  "R1724", # no-else-continue / ruff RET507
+  "R1725", # super-with-arguments / ruff UP008
+  "R1728", # consider-using-generator / ruff C417
+  "R1729", # use-a-generator / ruff C419
+  "R1730", # consider-using-min-builtin / ruff PLR1730
+  "R1731", # consider-using-max-builtin / ruff PLR1730
+  "R1732", # consider-using-with / ruff SIM115
+  "R1733", # unnecessary-dict-index-lookup / ruff PLR1733
+  "R1734", # use-list-literal / ruff C405
+  "R1735", # use-dict-literal / ruff C406
+  "R1736", # unnecessary-list-index-lookup / ruff PLR1736
+  "R2004", # magic-value-comparison / ruff PLR2004
+  "R2044", # empty-comment / ruff PLR2044
+  "R5501", # else-if-used / ruff PLR5501
+  "R6002", # consider-using-alias / ruff UP006
+  "R6003", # consider-alternative-union-syntax / ruff UP007
+  "R6104", # consider-using-augmented-assign / ruff PLR6104
+  "R6201", # use-set-for-membership / ruff PLR6201
+  "R6301", # no-self-use / ruff PLR6301
+  "W0102", # dangerous-default-value / ruff B006
+  "W0104", # pointless-statement / ruff B018
+  "W0106", # expression-not-assigned / ruff B018
+  "W0107", # unnecessary-pass / ruff PIE790
+  "W0108", # unnecessary-lambda / ruff PLW0108
+  "W0109", # duplicate-key / ruff F601
+  "W0120", # useless-else-on-loop / ruff PLW0120
+  "W0122", # exec-used / ruff S102
+  "W0123", # eval-used / ruff PGH001
+  "W0127", # self-assigning-variable / ruff PLW0127
+  "W0129", # assert-on-string-literal / ruff PLW0129
+  "W0130", # duplicate-value / ruff B033
+  "W0131", # named-expr-without-context / ruff PLW0131
+  "W0133", # pointless-exception-statement / ruff PLW0133
+  "W0150", # lost-exception / ruff B012
+  "W0160", # consider-ternary-expression / ruff SIM108
+  "W0177", # nan-comparison / ruff PLW0117
+  "W0199", # assert-on-tuple / ruff F631
+  "W0211", # bad-staticmethod-argument / ruff PLW0211
+  "W0212", # protected-access / ruff SLF001
+  "W0245", # super-without-brackets / ruff PLW0245
+  "W0301", # unnecessary-semicolon / ruff E703
+  "W0401", # wildcard-import / ruff F403
+  "W0404", # reimported / ruff F811
+  "W0406", # import-self / ruff PLW0406
+  "W0410", # misplaced-future / ruff F404
+  "W0511", # fixme / ruff PLW0511
+  "W0602", # global-variable-not-assigned / ruff PLW0602
+  "W0603", # global-statement / ruff PLW0603
+  "W0604", # global-at-module-level / ruff PLW0604
+  "W0611", # unused-import / ruff F401
+  "W0612", # unused-variable / ruff F841
+  "W0613", # unused-argument / ruff ARG001
+  "W0622", # redefined-builtin / ruff A001
+  "W0640", # cell-var-from-loop / ruff B023
+  "W0702", # bare-except / ruff E722
+  "W0705", # duplicate-except / ruff B014
+  "W0706", # try-except-raise / ruff TRY302
+  "W0707", # raise-missing-from / ruff TRY200
+  "W0711", # binary-op-exception / ruff PLW0711
+  "W0718", # broad-exception-caught / ruff PLW0718
+  "W0719", # broad-exception-raised / ruff TRY002
+  "W1113", # keyword-arg-before-vararg / ruff B026
+  "W1201", # logging-not-lazy / ruff G
+  "W1202", # logging-format-interpolation / ruff G
+  "W1203", # logging-fstring-interpolation / ruff G
+  "W1300", # bad-format-string-key / ruff PLW1300
+  "W1301", # unused-format-string-key / ruff F504
+  "W1302", # bad-format-string / ruff PLW1302
+  "W1303", # missing-format-argument-key / ruff F524
+  "W1304", # unused-format-string-argument / ruff F507
+  "W1305", # format-combined-specification / ruff F525
+  "W1308", # duplicate-string-formatting-argument / ruff PLW1308
+  "W1309", # f-string-without-interpolation / ruff F541
+  "W1310", # format-string-without-interpolation / ruff F541
+  "W1401", # anomalous-backslash-in-string / ruff W605
+  "W1404", # implicit-str-concat / ruff ISC001
+  "W1405", # inconsistent-quotes / ruff Q000
+  "W1406", # redundant-u-string-prefix / ruff UP025
+  "W1501", # bad-open-mode / ruff PLW1501
+  "W1508", # invalid-envvar-default / ruff PLW1508
+  "W1509", # subprocess-popen-preexec-fn / ruff PLW1509
+  "W1510", # subprocess-run-check / ruff PLW1510
+  "W1514", # unspecified-encoding / ruff PLW1514
+  "W1515", # forgotten-debug-statement / ruff T100
+  "W1518", # method-cache-max-size-none / ruff B019
+  "W1641", # eq-without-hash / ruff PLW1641
+  "W2101", # useless-with-lock / ruff PLW2101
+  "W2402", # non-ascii-file-name / ruff N999
+  "W2901", # redefined-loop-name / ruff PLW2901
+  "W3201", # bad-dunder-name / ruff PLW3201
+  "W3301", # nested-min-max / ruff PLW3301
+  "duplicate-code",
   "too-few-public-methods",
-  "too-many-instance-attributes",
-  "too-many-locals"
+  "too-many-instance-attributes"
 ]
 
 [tool.pytest.ini_options]
-addopts = "-n auto --ignore=tests/fixtures"
+addopts = "-ra --showlocals --durations=10"
+testpaths = "tests"
 tmp_path_retention_policy = "failed"
 verbosity_assertions = 2
 
 [tool.ruff]
 builtins = ["__"]
-exclude = ["_version.py", "tests/fixtures"]
+exclude = ["tests/fixtures"]
 fix = true
-ignore = [
-]
 line-length = 100
-select = ["ALL"]
-target-version = "py39"
+target-version = "py310"
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint]
+select = ["ALL"]
+
+[tool.ruff.lint.flake8-pytest-style]
 parametrize-values-type = "tuple"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-after-imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports
 lines-between-types = 1 # Separate import/from with 1 line
 
-[tool.ruff.per-file-ignores]
-"src/ansible_creator/resources/new_collection/tests/**" = ["S101", "S602", "T201"]
+[tool.ruff.lint.per-file-ignores]
+# SIM108, file is generated
+"_version.py" = ["SIM108"]
+"src/ansible_creator/resources/new_collection/tests/**" = ["SLF001", "S101", "S602", "T201"]
+# SLF001: Allow private member access in tests
 # S101 Allow assert in tests
 # S602 Allow shell in test
 # T201 Allow print in tests
-"tests/**" = ["S101", "S602", "T201"]
+"tests/**" = ["SLF001", "S101", "S602", "T201"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,7 @@ disable = [
 
 [tool.pytest.ini_options]
 addopts = "-ra --showlocals --durations=10"
+norecursedirs = "tests/fixtures"
 testpaths = "tests"
 tmp_path_retention_policy = "failed"
 verbosity_assertions = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 
 from subprocess import CalledProcessError, CompletedProcess
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -15,6 +15,7 @@ from ansible_creator.utils import TermFeatures
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import re
-import sys
 
+from collections.abc import Callable
 from subprocess import CalledProcessError, CompletedProcess
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 
 if TYPE_CHECKING:
@@ -26,44 +26,25 @@ def test_run_help(cli: cli_type) -> None:
     assert result.returncode == 0
 
     # temporary assertion fix until we write custom helper
-    if sys.version_info < (3, 10):
-        assert (
-            dedent(
-                """\
-                usage: ansible-creator [-h] [--version] {init} ...
 
-                Tool to scaffold Ansible Content. Get started by looking at the help text.
+    assert (
+        dedent(
+            """\
+            usage: ansible-creator [-h] [--version] {init} ...
 
-                optional arguments:
-                  -h, --help  show this help message and exit
-                  --version   Print ansible-creator version and exit.
+            Tool to scaffold Ansible Content. Get started by looking at the help text.
 
-                Commands:
-                  {init}      The subcommand to invoke.
-                    init      Initialize an Ansible Collection.
-                """,
-            )
-            in result.stdout
+            options:
+                -h, --help  show this help message and exit
+                --version   Print ansible-creator version and exit.
+
+            Commands:
+                {init}      The subcommand to invoke.
+                init      Initialize an Ansible Collection.
+            """,
         )
-    else:
-        assert (
-            dedent(
-                """\
-                usage: ansible-creator [-h] [--version] {init} ...
-
-                Tool to scaffold Ansible Content. Get started by looking at the help text.
-
-                options:
-                  -h, --help  show this help message and exit
-                  --version   Print ansible-creator version and exit.
-
-                Commands:
-                  {init}      The subcommand to invoke.
-                    init      Initialize an Ansible Collection.
-                """,
-            )
-            in result.stdout
-        )
+        in result.stdout
+    )
 
 
 def test_run_no_subcommand(cli: cli_type) -> None:

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import re
+import sys
 
 from collections.abc import Callable
+from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
-from textwrap import dedent
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 cli_type = Callable[[Any], CompletedProcess[str] | CalledProcessError]
+
+CREATOR_BIN = Path(sys.executable).parent / "ansible-creator"
 
 
 def test_run_help(cli: cli_type) -> None:
@@ -22,29 +22,13 @@ def test_run_help(cli: cli_type) -> None:
     Args:
         cli: cli_run function.
     """
-    result = cli("ansible-creator --help")
-    assert result.returncode == 0
+    # Get the path to the current python interpreter
+    result = cli(f"{CREATOR_BIN} --help")
+    assert result.returncode == 0, (result.stdout, result.stderr)
 
-    # temporary assertion fix until we write custom helper
-
-    assert (
-        dedent(
-            """\
-            usage: ansible-creator [-h] [--version] {init} ...
-
-            Tool to scaffold Ansible Content. Get started by looking at the help text.
-
-            options:
-                -h, --help  show this help message and exit
-                --version   Print ansible-creator version and exit.
-
-            Commands:
-                {init}      The subcommand to invoke.
-                init      Initialize an Ansible Collection.
-            """,
-        )
-        in result.stdout
-    )
+    assert "Print ansible-creator version and exit." in result.stdout
+    assert "The subcommand to invoke." in result.stdout
+    assert "Initialize an Ansible Collection." in result.stdout
 
 
 def test_run_no_subcommand(cli: cli_type) -> None:
@@ -53,17 +37,9 @@ def test_run_no_subcommand(cli: cli_type) -> None:
     Args:
         cli: cli_run function.
     """
-    result = cli("ansible-creator")
+    result = cli(str(CREATOR_BIN))
     assert result.returncode != 0
-    assert (
-        dedent(
-            """\
-            usage: ansible-creator [-h] [--version] {init} ...
-            ansible-creator: error: the following arguments are required: subcommand
-            """,
-        )
-        in result.stderr
-    )
+    assert "the following arguments are required: subcommand" in result.stderr
 
 
 def test_run_init_no_input(cli: cli_type) -> None:
@@ -72,7 +48,7 @@ def test_run_init_no_input(cli: cli_type) -> None:
     Args:
         cli: cli_run function.
     """
-    result = cli("ansible-creator init")
+    result = cli(f"{CREATOR_BIN} init")
     assert result.returncode != 0
     assert (
         "Error: The argument 'collection' is required when scaffolding a collection"
@@ -91,7 +67,7 @@ def test_run_init_basic(cli: cli_type, tmp_path: Path) -> None:
     cli(f"mkdir -p {final_dest}")
 
     result = cli(
-        f"ansible-creator init testorg.testcol --init-path {final_dest}",
+        f"{CREATOR_BIN} init testorg.testcol --init-path {final_dest}",
     )
     assert result.returncode == 0
 
@@ -103,7 +79,7 @@ def test_run_init_basic(cli: cli_type, tmp_path: Path) -> None:
 
     # fail to override existing collection with force=false (default)
     result = cli(
-        f"ansible-creator init testorg.testcol --init-path {final_dest}",
+        f"{CREATOR_BIN} init testorg.testcol --init-path {final_dest}",
     )
 
     assert result.returncode != 0
@@ -121,7 +97,7 @@ def test_run_init_basic(cli: cli_type, tmp_path: Path) -> None:
     assert "However it will delete ALL existing contents in it." in result.stderr
 
     # override existing collection with force=true
-    result = cli(f"ansible-creator init testorg.testcol --init-path {tmp_path} --force")
+    result = cli(f"{CREATOR_BIN} init testorg.testcol --init-path {tmp_path} --force")
     assert result.returncode == 0
     assert (
         re.search("Warning: re-initializing existing directory", result.stdout)

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -35,8 +35,8 @@ class ConfigDict(TypedDict):
     scm_project: str | None
 
 
-@pytest.fixture()
-def cli_args(tmp_path: Path, output: Output) -> ConfigDict:
+@pytest.fixture(name="cli_args")
+def fixture_cli_args(tmp_path: Path, output: Output) -> ConfigDict:
     """Create a dict to use for a Init class object as fixture.
 
     Args:


### PR DESCRIPTION
Some remaining cleanup to normalize the config with ADT and ADE.

- Set the precommit black config to the black repo
- REconfigure the deps hook to match ADE and ADT
- Update the pylint config in the pyproject.toml
- Update the ruff config
- Other changes as needed to fix newly found lint and ruff errors
- Updated some tests so to run with formatting checks
- Update creator path in test to use current interpreter so they could be run with VsCode

**Note:** `Setting coverage check as failed due to coverage going down by 0.23% (94.57% on base -> 94.34% on head).` can be disregarded since it's less than 1% and there really weren't any test changes that should effect coverage
