### PR TITLE
chore: Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ env_list =
     pkg
     docs
 skip_missing_interpreters = true
-work_dir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 description = Run pytest under {basepython}


### PR DESCRIPTION
The `workdir` is not needed and causes the `COVERAGE_` environment variables to become realtive which can effect subprocess coverage collection.
