### PR TITLE
chore: Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ parallel = true
 source_pkgs = ["ansible_creator"]
 
 [tool.mypy]
+cache_dir = "./.cache/.mypy"
 exclude = 'tests/fixtures'
 files = ["src", "tests"]
 strict = true
@@ -313,6 +314,7 @@ fail-on = [
 
 [tool.pytest.ini_options]
 addopts = "-ra --showlocals --durations=10"
+cache_dir = "./.cache/.pytest"
 norecursedirs = "tests/fixtures"
 testpaths = "tests"
 tmp_path_retention_policy = "failed"
@@ -320,6 +322,7 @@ verbosity_assertions = 2
 
 [tool.ruff]
 builtins = ["__"]
+cache-dir = "./.cache/.ruff"
 exclude = ["tests/fixtures"]
 fix = true
 line-length = 100


### PR DESCRIPTION
Move tool cache into cache directory to prevent root directory pollution.
