### PR TITLE
Adding collection name requirement checks 

### DIFF
--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -72,25 +72,22 @@ class Config:
             msg = "Collection name has no effect when project is set to ansible-project."
             self.output.warning(msg)
 
-        # Validation for collection name according to Ansible requirements    
+        # Validation for collection name according to Ansible requirements
         if self.collection:
             fqcn = self.collection.split(".", maxsplit=1)
-            name_filter = re.compile(r'^(?!_)[a-z0-9_]+$')
-            
-            
+            name_filter = re.compile(r"^(?!_)[a-z0-9_]+$")
+
             if not name_filter.match(fqcn[0]) or not name_filter.match(fqcn[-1]):
                 msg = (
-                "Collection name can only contain lower case letters, underscores, and numbers"
-                " and cannot begin with an underscore."
-            )
+                    "Collection name can only contain lower case letters, underscores, and numbers"
+                    " and cannot begin with an underscore."
+                )
                 raise CreatorError(msg)
-            
+
             if len(fqcn[0]) <= MIN_COLLECTION_NAME_LEN or len(fqcn[-1]) <= MIN_COLLECTION_NAME_LEN:
-                msg = (
-                "Collection namespace and name must be longer than 2 characters."
-            )
+                msg = "Collection namespace and name must be longer than 2 characters."
                 raise CreatorError(msg)
-            
+
             object.__setattr__(self, "namespace", fqcn[0])
             object.__setattr__(self, "collection_name", fqcn[-1])
 

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ansible_creator.constants import MIN_COLLECTION_NAME_LEN
 from ansible_creator.exceptions import CreatorError
 from ansible_creator.utils import expand_path
 
@@ -69,8 +72,25 @@ class Config:
             msg = "Collection name has no effect when project is set to ansible-project."
             self.output.warning(msg)
 
+        # Validation for collection name according to Ansible requirements    
         if self.collection:
             fqcn = self.collection.split(".", maxsplit=1)
+            name_filter = re.compile(r'^(?!_)[a-z0-9_]+$')
+            
+            
+            if not name_filter.match(fqcn[0]) or not name_filter.match(fqcn[-1]):
+                msg = (
+                "Collection name can only contain lower case letters, underscores, and numbers"
+                " and cannot begin with an underscore."
+            )
+                raise CreatorError(msg)
+            
+            if len(fqcn[0]) <= MIN_COLLECTION_NAME_LEN or len(fqcn[-1]) <= MIN_COLLECTION_NAME_LEN:
+                msg = (
+                "Collection namespace and name must be longer than 2 characters."
+            )
+                raise CreatorError(msg)
+            
             object.__setattr__(self, "namespace", fqcn[0])
             object.__setattr__(self, "collection_name", fqcn[-1])
 

--- a/src/ansible_creator/constants.py
+++ b/src/ansible_creator/constants.py
@@ -5,6 +5,8 @@ GLOBAL_TEMPLATE_VARS = {
     "DEV_FILE_IMAGE": "ghcr.io/ansible/ansible-workspace-env-reference:latest",
 }
 
+MIN_COLLECTION_NAME_LEN = 2
+
 # directory names that will be skipped in any resource
 SKIP_DIRS = ("__pycache__",)
 # file types that will be skipped in any resource

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -296,6 +296,7 @@ def test_warning(
         is not None
     )
 
+
 def test_collection_name_char_error(
     cli_args: ConfigDict,
 ) -> None:
@@ -312,11 +313,12 @@ def test_collection_name_char_error(
     cli_args["scm_org"] = ""
     cli_args["scm_project"] = ""
     fail_msg = (
-                "Collection name can only contain lower case letters, underscores, and numbers"
-                " and cannot begin with an underscore."
-            )
+        "Collection name can only contain lower case letters, underscores, and numbers"
+        " and cannot begin with an underscore."
+    )
     with pytest.raises(CreatorError, match=fail_msg):
         Init(Config(**cli_args))
+
 
 def test_collection_name_length_error(
     cli_args: ConfigDict,
@@ -336,6 +338,7 @@ def test_collection_name_length_error(
     fail_msg = "Collection namespace and name must be longer than 2 characters."
     with pytest.raises(CreatorError, match=fail_msg):
         Init(Config(**cli_args))
+
 
 def test_delete_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Test a remove fails gracefully.

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -296,6 +296,46 @@ def test_warning(
         is not None
     )
 
+def test_collection_name_char_error(
+    cli_args: ConfigDict,
+) -> None:
+    """Test a collection's name for disallowed characters.
+
+    Validation for: ansible-creator init <collection>
+
+    Args:
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["collection"] = "BAD.NAME"
+    cli_args["project"] = "collection"
+    cli_args["init_path"] = ""
+    cli_args["scm_org"] = ""
+    cli_args["scm_project"] = ""
+    fail_msg = (
+                "Collection name can only contain lower case letters, underscores, and numbers"
+                " and cannot begin with an underscore."
+            )
+    with pytest.raises(CreatorError, match=fail_msg):
+        Init(Config(**cli_args))
+
+def test_collection_name_length_error(
+    cli_args: ConfigDict,
+) -> None:
+    """Test a collection's name for length greater than 2 characters.
+
+    Validation for: ansible-creator init <collection>
+
+    Args:
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["collection"] = "na.co"
+    cli_args["project"] = "collection"
+    cli_args["init_path"] = ""
+    cli_args["scm_org"] = ""
+    cli_args["scm_project"] = ""
+    fail_msg = "Collection namespace and name must be longer than 2 characters."
+    with pytest.raises(CreatorError, match=fail_msg):
+        Init(Config(**cli_args))
 
 def test_delete_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Test a remove fails gracefully.


### PR DESCRIPTION
FIxes: #230

Adds checks for collection name requirements and new tests for the new checks. 

Examples:

Command: `ansible-creator init COLLECTION.NAME`
Error output: `Error: Collection name can only contain lower case letters, underscores, and numbers and cannot begin with an underscore.`

Command: `ansible-creator init na.co`
Error output:  `Error: Collection namespace and name must be longer than 2 characters.`