### PR TITLE
Assorted CI fixes for scaffolded content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ lines-between-types = 1 # Separate import/from with 1 line
 [tool.ruff.lint.per-file-ignores]
 "_version.py" = ["SIM108"]
 "src/ansible_creator/resources/new_collection/tests/**" = ["SLF001", "S101", "S602", "T201"]
+"src/ansible_creator/resources/new_collection/tests/unit/__init__.py" = ["D104"]
 "tests/**" = ["SLF001", "S101", "S602", "T201"]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/ansible_creator/resources/ansible_project/collections/requirements.yml.j2
+++ b/src/ansible_creator/resources/ansible_project/collections/requirements.yml.j2
@@ -9,6 +9,8 @@ collections:
   - name: ansible.utils
     version: 4.0.0
 
+  - name: cisco.ios
+
   - name: https://github.com/redhat-cop/network.backup
     type: git
 

--- a/src/ansible_creator/resources/new_collection/README.md.j2
+++ b/src/ansible_creator/resources/new_collection/README.md.j2
@@ -2,9 +2,8 @@
 
 This repository contains the `{{ namespace }}.{{ collection_name }}` Ansible Collection.
 
-## Tested with Ansible
-
-Tested with ansible-core >=2.14 releases and the current development version of ansible-core.
+<!--start requires_ansible-->
+<!--end requires_ansible-->
 
 ## External requirements
 
@@ -12,11 +11,12 @@ Some modules and plugins require external libraries. Please check the requiremen
 
 ## Included content
 
-Please check the included content on the [Ansible Galaxy page for this collection](https://galaxy.ansible.com/{{ namespace }}/{{ collection_name }}).
+<!--start collection content-->
+<!--end collection content-->
 
 ## Using this collection
 
-```
+```bash
     ansible-galaxy collection install {{ namespace }}.{{ collection_name }}
 ```
 

--- a/src/ansible_creator/resources/new_collection/extensions/molecule/utils/vars/vars.yml
+++ b/src/ansible_creator/resources/new_collection/extensions/molecule/utils/vars/vars.yml
@@ -1,3 +1,3 @@
-collection_root: "{{ lookup( 'env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
+collection_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
 integration_tests_path: "{{ collection_root }}/tests/integration/targets/"
 molecule_scenario_name: "{{ molecule_scenario_directory | basename }}"

--- a/src/ansible_creator/resources/new_collection/extensions/molecule/utils/vars/vars.yml
+++ b/src/ansible_creator/resources/new_collection/extensions/molecule/utils/vars/vars.yml
@@ -1,3 +1,3 @@
-collection_root: "{{ lookup ( 'env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
+collection_root: "{{ lookup( 'env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
 integration_tests_path: "{{ collection_root }}/tests/integration/targets/"
 molecule_scenario_name: "{{ molecule_scenario_directory | basename }}"

--- a/src/ansible_creator/resources/new_collection/extensions/molecule/utils/vars/vars.yml
+++ b/src/ansible_creator/resources/new_collection/extensions/molecule/utils/vars/vars.yml
@@ -1,3 +1,3 @@
-collection_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
+collection_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/.."
 integration_tests_path: "{{ collection_root }}/tests/integration/targets/"
 molecule_scenario_name: "{{ molecule_scenario_directory | basename }}"

--- a/src/ansible_creator/resources/new_collection/meta/runtime.yml
+++ b/src/ansible_creator/resources/new_collection/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/src/ansible_creator/resources/new_collection/plugins/filter/hello_world.py.j2
+++ b/src/ansible_creator/resources/new_collection/plugins/filter/hello_world.py.j2
@@ -7,8 +7,31 @@ __metaclass__ = type  # pylint: disable=C0103
 
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     from typing import Callable
+
+
+DOCUMENTATION = """
+    name: hello_world
+    author: {{ namespace | capitalize }} {{ collection_name | capitalize }}
+    version_added: "1.0.0"
+    short_description: Demo filter plugin that returns a Hello message.
+    description:
+      - This is a demo filter plugin designed to return Hello message.
+    options:
+      name:
+        description: Value specified here is appended to the Hello message.
+        type: str
+"""
+
+EXAMPLES = """
+# hello_world filter example
+{% raw %}
+- name: Display a hello message
+  ansible.builtin.debug:
+    msg: "{{ 'ansible-creator' {%- endraw %} | {{ namespace }}.{{ collection_name }}.hello_world }}"
+"""
 
 
 def _hello_world(name: str) -> str:

--- a/src/ansible_creator/resources/new_collection/plugins/filter/hello_world.py.j2
+++ b/src/ansible_creator/resources/new_collection/plugins/filter/hello_world.py.j2
@@ -1,8 +1,7 @@
 """A hello-world filter plugin in {{ namespace }}.{{ collection_name }}."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
-from __future__ import annotations
 
 __metaclass__ = type  # pylint: disable=C0103
 

--- a/src/ansible_creator/resources/new_collection/tests/unit/__init__.py
+++ b/src/ansible_creator/resources/new_collection/tests/unit/__init__.py
@@ -1,1 +1,0 @@
-"""Unit tests for the collection."""

--- a/tests/fixtures/collection/testorg/testcol/README.md
+++ b/tests/fixtures/collection/testorg/testcol/README.md
@@ -2,9 +2,8 @@
 
 This repository contains the `testorg.testcol` Ansible Collection.
 
-## Tested with Ansible
-
-Tested with ansible-core >=2.14 releases and the current development version of ansible-core.
+<!--start requires_ansible-->
+<!--end requires_ansible-->
 
 ## External requirements
 
@@ -12,11 +11,12 @@ Some modules and plugins require external libraries. Please check the requiremen
 
 ## Included content
 
-Please check the included content on the [Ansible Galaxy page for this collection](https://galaxy.ansible.com/testorg/testcol).
+<!--start collection content-->
+<!--end collection content-->
 
 ## Using this collection
 
-```
+```bash
     ansible-galaxy collection install testorg.testcol
 ```
 

--- a/tests/fixtures/collection/testorg/testcol/extensions/molecule/utils/vars/vars.yml
+++ b/tests/fixtures/collection/testorg/testcol/extensions/molecule/utils/vars/vars.yml
@@ -1,3 +1,3 @@
-collection_root: "{{ lookup( 'env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
+collection_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
 integration_tests_path: "{{ collection_root }}/tests/integration/targets/"
 molecule_scenario_name: "{{ molecule_scenario_directory | basename }}"

--- a/tests/fixtures/collection/testorg/testcol/extensions/molecule/utils/vars/vars.yml
+++ b/tests/fixtures/collection/testorg/testcol/extensions/molecule/utils/vars/vars.yml
@@ -1,3 +1,3 @@
-collection_root: "{{ lookup ( 'env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
+collection_root: "{{ lookup( 'env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
 integration_tests_path: "{{ collection_root }}/tests/integration/targets/"
 molecule_scenario_name: "{{ molecule_scenario_directory | basename }}"

--- a/tests/fixtures/collection/testorg/testcol/extensions/molecule/utils/vars/vars.yml
+++ b/tests/fixtures/collection/testorg/testcol/extensions/molecule/utils/vars/vars.yml
@@ -1,3 +1,3 @@
-collection_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY' ) }}/.."
+collection_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/.."
 integration_tests_path: "{{ collection_root }}/tests/integration/targets/"
 molecule_scenario_name: "{{ molecule_scenario_directory | basename }}"

--- a/tests/fixtures/collection/testorg/testcol/meta/runtime.yml
+++ b/tests/fixtures/collection/testorg/testcol/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/tests/fixtures/collection/testorg/testcol/plugins/filter/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/filter/hello_world.py
@@ -7,8 +7,31 @@ __metaclass__ = type  # pylint: disable=C0103
 
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     from typing import Callable
+
+
+DOCUMENTATION = """
+    name: hello_world
+    author: Testorg Testcol
+    version_added: "1.0.0"
+    short_description: Demo filter plugin that returns a Hello message.
+    description:
+      - This is a demo filter plugin designed to return Hello message.
+    options:
+      name:
+        description: Value specified here is appended to the Hello message.
+        type: str
+"""
+
+EXAMPLES = """
+# hello_world filter example
+
+- name: Display a hello message
+  ansible.builtin.debug:
+    msg: "{{ 'ansible-creator' | testorg.testcol.hello_world }}"
+"""
 
 
 def _hello_world(name: str) -> str:

--- a/tests/fixtures/collection/testorg/testcol/plugins/filter/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/filter/hello_world.py
@@ -1,8 +1,7 @@
 """A hello-world filter plugin in testorg.testcol."""
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
-from __future__ import annotations
 
 __metaclass__ = type  # pylint: disable=C0103
 

--- a/tests/fixtures/collection/testorg/testcol/tests/unit/__init__.py
+++ b/tests/fixtures/collection/testorg/testcol/tests/unit/__init__.py
@@ -1,1 +1,0 @@
-"""Unit tests for the collection."""

--- a/tests/fixtures/project/ansible_project/collections/requirements.yml
+++ b/tests/fixtures/project/ansible_project/collections/requirements.yml
@@ -9,6 +9,8 @@ collections:
   - name: ansible.utils
     version: 4.0.0
 
+  - name: cisco.ios
+
   - name: https://github.com/redhat-cop/network.backup
     type: git
 


### PR DESCRIPTION
Currently, both the scaffolded content types fail GHA workflow checks and pre-commit hooks. This patch fixes that.