### PR TITLE
chore: Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,6 @@ repos:
     rev: v3.2.2
     hooks:
       - id: pylint
-        language_version: "3.10"
         args:
           - --output-format=colorized
         additional_dependencies:

--- a/src/ansible_creator/compat.py
+++ b/src/ansible_creator/compat.py
@@ -11,6 +11,6 @@ import sys
 if sys.version_info >= (3, 11):
     from importlib.resources.abc import Traversable as _Traversable
 else:
-    from importlib.abc import Traversable as _Traversable
+    from importlib.abc import Traversable as _Traversable  # pylint: disable = deprecated-class
 
 Traversable = _Traversable

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -20,7 +20,21 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Config:
-    """The application configuration for ansible-creator."""
+    """The application configuration for ansible-creator.
+
+    Attributes:
+        creator_version: The version of ansible-creator.
+        output: The output object to use for logging.
+        subcommand: The subcommand to execute.
+        collection: The collection name to scaffold.
+        force: Whether to overwrite existing files.
+        init_path: The path to initialize the project.
+        project: The type of project to scaffold.
+        scm_org: The SCM organization for the project.
+        scm_project: The SCM project for the project.
+        collection_name: The name of the collection.
+        namespace: The namespace for the collection.
+    """
 
     creator_version: str
     output: Output

--- a/src/ansible_creator/output.py
+++ b/src/ansible_creator/output.py
@@ -64,7 +64,27 @@ def console_width() -> int:
 
 
 class Color:
-    """Color constants."""
+    """Color constants.
+
+    Attributes:
+        BLACK: Black color
+        RED: Red color
+        GREEN: Green color
+        YELLOW: Yellow color
+        BLUE: Blue color
+        MAGENTA: Magenta color
+        CYAN: Cyan color
+        WHITE: White color
+        GREY: Bright black color
+        BRIGHT_RED: Bright red color
+        BRIGHT_GREEN: Bright green color
+        BRIGHT_YELLOW: Bright yellow color
+        BRIGHT_BLUE: Bright blue color
+        BRIGHT_MAGENTA: Bright magenta color
+        BRIGHT_CYAN: Bright cyan color
+        BRIGHT_WHITE: Bright white color
+        END: End
+    """
 
     BLACK = "\033[30m"
     RED = "\033[31m"
@@ -86,7 +106,17 @@ class Color:
 
 
 class Level(Enum):
-    """An exit message prefix."""
+    """An exit message prefix.
+
+    Attributes:
+        CRITICAL: Critical
+        DEBUG: Debug
+        ERROR: Error
+        HINT: Hint
+        INFO: Info
+        NOTE: Note
+        WARNING: Warning
+    """
 
     CRITICAL = "Critical"
     DEBUG = "Debug"
@@ -142,11 +172,14 @@ class Level(Enum):
 
 @dataclass
 class Msg:
-    """An object to hold a message to present when exiting."""
+    """An object to hold a message to present when exiting.
 
-    #: The message that will be presented
+    Attributes:
+        message: The message that will be presented
+        prefix: The prefix for the message, used for formatting
+    """
+
     message: str
-    #: The prefix for the message, used for formatting
     prefix: Level = Level.ERROR
 
     @property

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -27,7 +27,12 @@ PATH_REPLACERS = {
 
 @dataclass
 class TermFeatures:
-    """Terminal features."""
+    """Terminal features.
+
+    Attributes:
+        color: Enable color output.
+        links: Enable clickable links.
+    """
 
     color: bool
     links: bool
@@ -57,26 +62,29 @@ def expand_path(path: str) -> Path:
 
 @dataclass
 class Copier:
-    """Configuration for the Copier class."""
+    """Configuration for the Copier class.
+
+    Attributes:
+        resources: List of resource containers to copy.
+        resource_id: The id of the resource to copy.
+        dest: The destination path to copy resources to.
+        output: An instance of the Output class.
+        allow_overwrite: A list of paths that should be overwritten at destination.
+        index: Index of the current resource being copied.
+        resource_root: Root path for the resources.
+        templar: An instance of the Templar class.
+        template_data: A dictionary containing the original data to render templates with.
+    """
 
     resources: list[str]
-    """ list of resource containers to copy"""
     resource_id: str
-    """the id of the resource to copy"""
     dest: Path
-    """the destination path to copy resources to"""
     output: Output
-    """an instance of the Output class"""
     allow_overwrite: list[str] | None = None
-    """a list of paths that should be overwritten at destination"""
     index: int = 0
-    """index of the current resource being copied"""
     resource_root: str = "ansible_creator.resources"
-    """root path for the resources"""
     templar: Templar | None = None
-    """an instance of the Templar class"""
     template_data: dict[str, str] = field(default_factory=dict)
-    """a dictionary containing the original data to render templates with"""
 
     @property
     def resource(self: Copier) -> str:

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -21,7 +21,19 @@ from tests.defaults import FIXTURES_DIR
 
 
 class ConfigDict(TypedDict):
-    """Type hint for Config dictionary."""
+    """Type hint for Config dictionary.
+
+    Attributes:
+        creator_version: The version of the creator.
+        output: The output object to use for logging.
+        subcommand: The subcommand to execute.
+        collection: The name of the collection.
+        init_path: Path to initialize the project.
+        project: The type of project to scaffold.
+        force: Force overwrite of existing directory.
+        scm_org: The SCM organization for the project.
+        scm_project: The SCM project for the project.
+    """
 
     creator_version: str
     output: Output
@@ -417,7 +429,21 @@ def test_collection_name_not_set(output: Output, tmp_path: Path) -> None:
     """
 
     class FakeConfig:
-        """Fake Config class, ours protects from this error."""
+        """Fake Config class, ours protects from this error.
+
+        Attributes:
+            collection: The name of the collection.
+            collection_name: The name of the collection.
+            creator_version: The version of the creator.
+            force: Force overwrite of existing directory.
+            init_path: Path to initialize the project.
+            project: The type of project to scaffold.
+            output: The output object to use for logging.
+            namespace: The namespace for the collection.
+            scm_org: The SCM organization for the project.
+            scm_project: The SCM project for the project.
+            subcommand: The subcommand to execute.
+        """
 
         collection: str = "foo.bar"
         collection_name: str | None = None
@@ -448,7 +474,21 @@ def test_scm_vals_not_set(output: Output, tmp_path: Path) -> None:
     """
 
     class FakeConfig:
-        """Fake Config class, ours protects from this error."""
+        """Fake Config class, ours protects from this error.
+
+        Attributes:
+            collection: The name of the collection.
+            collection_name: The name of the collection.
+            creator_version: The version of the creator.
+            force: Force overwrite of existing directory.
+            init_path: Path to initialize the project.
+            project: The type of project to scaffold.
+            output: The output object to use for logging.
+            namespace: The namespace for the collection.
+            scm_org: The SCM organization for the project.
+            scm_project: The SCM project for the project.
+            subcommand: The subcommand to execute.
+        """
 
         collection: str = "foo.bar"
         collection_name: str | None = None


### PR DESCRIPTION
Restore pylint version to match other repositories.

This is a valid deprecation message, so we'll disable reporting via pylint until we drop 3.10.

Also added some class doc strings to pass latest version of pydoclint
