### PR TITLE
avoid hardcoded path in test conf

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ from ansible_creator.utils import TermFeatures
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 
 os.environ["HOME"] = str(Path.home())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-
+from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
 from typing import TYPE_CHECKING, Any
 
@@ -13,13 +13,12 @@ import pytest
 from ansible_creator.output import Output
 from ansible_creator.utils import TermFeatures
 
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
 
-os.environ["HOME"] = "/home/ansible"
+os.environ["HOME"] = str(Path.home())
 os.environ["DEV_WORKSPACE"] = "collections/ansible_collections"
 
 
@@ -51,6 +50,16 @@ def output(tmp_path: Path) -> Output:
         term_features=TermFeatures(color=False, links=False),
         verbosity=0,
     )
+
+
+@pytest.fixture()
+def home_path() -> Path:
+    """Create the home directory as a fixture.
+
+    Returns:
+        Path: Home directory.
+    """
+    return Path.home()
 
 
 def cli_run(args: list[str]) -> CompletedProcess[str] | CalledProcessError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
 from typing import TYPE_CHECKING, Any
@@ -12,6 +13,7 @@ import pytest
 
 from ansible_creator.output import Output
 from ansible_creator.utils import TermFeatures
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import runpy
 import sys
+
 from pathlib import Path
 
 import pytest

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import runpy
 import sys
+
 from pathlib import Path, PosixPath
 
 import pytest

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import re
 import runpy
 import sys
-
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import pytest
 
@@ -230,12 +229,12 @@ def test_missing_j2(monkeypatch: pytest.MonkeyPatch) -> None:
         ansible_creator.templar.Templar()
 
 
-def test_cli_init_output(monkeypatch: pytest.MonkeyPatch, home_path: Path.home) -> None:
+def test_cli_init_output(monkeypatch: pytest.MonkeyPatch, home_path: PosixPath) -> None:
     """Test CLI init_output method.
 
     Args:
-        home_path: Home directory
         monkeypatch: Pytest monkeypatch fixture.
+        home_path: Home directory.
     """
     sysargs = [
         "ansible-creator",

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 import runpy
 import sys
-
 from pathlib import Path
 
 import pytest
@@ -33,8 +32,8 @@ def test_configuration_class(output: Output) -> None:
     )
     assert app_config.namespace == "testorg"
     assert app_config.collection_name == "testcol"
-    linux_path = Path("/home/ansible")
-    mac_os_path = Path("/System/Volumes/Data/home/ansible")
+    linux_path = Path.home()
+    mac_os_path = Path.home()
     assert app_config.init_path in [linux_path, mac_os_path]
 
 
@@ -62,7 +61,7 @@ def test_configuration_class(output: Output) -> None:
                 "ansible-creator",
                 "init",
                 "--project=ansible-project",
-                "--init-path=/home/ansible/my-ansible-project",
+                f"--init-path={Path.home()}/my-ansible-project",
                 "--scm-org=weather",
                 "--scm-project=demo",
             ],
@@ -75,7 +74,7 @@ def test_configuration_class(output: Output) -> None:
                 "json": False,
                 "verbose": 0,
                 "collection": None,
-                "init_path": "/home/ansible/my-ansible-project",
+                "init_path": f"{Path.home()}/my-ansible-project",
                 "force": False,
                 "project": "ansible-project",
                 "scm_org": "weather",
@@ -87,7 +86,7 @@ def test_configuration_class(output: Output) -> None:
                 "ansible-creator",
                 "init",
                 "testorg.testcol",
-                "--init-path=/home/ansible",
+                f"--init-path={Path.home()}",
                 "-vvv",
                 "--json",
                 "--no-ansi",
@@ -105,7 +104,7 @@ def test_configuration_class(output: Output) -> None:
                 "json": True,
                 "verbose": 3,
                 "collection": "testorg.testcol",
-                "init_path": "/home/ansible",
+                "init_path": f"{Path.home()}",
                 "force": True,
                 "project": "collection",  # default value
             },
@@ -117,7 +116,7 @@ def test_configuration_class(output: Output) -> None:
                 "--project=ansible-project",
                 "--scm-org=weather",
                 "--scm-project=demo",
-                "--init-path=/home/ansible/my-ansible-project",
+                f"--init-path={Path.home()}/my-ansible-project",
                 "-vvv",
                 "--json",
                 "--no-ansi",
@@ -135,7 +134,7 @@ def test_configuration_class(output: Output) -> None:
                 "json": True,
                 "verbose": 3,
                 "collection": None,
-                "init_path": "/home/ansible/my-ansible-project",
+                "init_path": f"{Path.home()}/my-ansible-project",
                 "force": True,
                 "project": "ansible-project",
                 "scm_org": "weather",
@@ -231,17 +230,18 @@ def test_missing_j2(monkeypatch: pytest.MonkeyPatch) -> None:
         ansible_creator.templar.Templar()
 
 
-def test_cli_init_output(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_init_output(monkeypatch: pytest.MonkeyPatch, home_path: Path.home) -> None:
     """Test CLI init_output method.
 
     Args:
+        home_path: Home directory
         monkeypatch: Pytest monkeypatch fixture.
     """
     sysargs = [
         "ansible-creator",
         "init",
         "testorg.testcol",
-        "--init-path=/home/ansible",
+        f"--init-path={home_path}",
         "-vvv",
         "--json",
         "--no-ansi",
@@ -360,7 +360,7 @@ def test_is_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
         "ansible-creator",
         "init",
         "testorg.testcol",
-        "/home/ansible",
+        f"{Path.home()}",
     ]
 
     monkeypatch.setattr("sys.argv", sysargs)
@@ -383,7 +383,7 @@ def test_not_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
         "ansible-creator",
         "init",
         "testorg.testcol",
-        "/home/ansible",
+        f"{Path.home()}",
     ]
 
     monkeypatch.setattr("sys.argv", sysargs)

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -33,9 +33,8 @@ def test_configuration_class(output: Output) -> None:
     )
     assert app_config.namespace == "testorg"
     assert app_config.collection_name == "testcol"
-    linux_path = Path.home()
-    mac_os_path = Path.home()
-    assert app_config.init_path in [linux_path, mac_os_path]
+    home_path = Path.home()
+    assert app_config.init_path == home_path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change uses pathlib in the test conf instead of hardcoding it to the home directory for the ansible user. Related to https://github.com/ansible/ansible-creator/pull/250