### PR TITLE
Add communication details

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A CLI tool for scaffolding all your Ansible Content.
 ## Installation
 
 ```shell
-$ pip install ansible-creator
+pip install ansible-creator
 ```
 
 ```shell
@@ -34,21 +34,39 @@ Options:
 
 ## Usage
 
-Full documentation on how to use this, along with it's integration with VS Code Ansible Extension can be found in https://ansible.readthedocs.io/projects/creator/.
+Full documentation on how to use `ansible-creator`, including integration with the VS Code Ansible Extension, is available in
+[ansible-creator documentation](https://ansible.readthedocs.io/projects/creator/).
 
 ## Command line completion
 
 `ansible-creator` has experimental command line completion for common shells. Please ensure you have the `argcomplete` package installed and configured.
 
 ```shell
-$ pip install argcomplete --user
-$ activate-global-python-argcomplete --user
+pip install argcomplete --user
+activate-global-python-argcomplete --user
 ```
 
 ## Upcoming features
 
 - Scaffold Ansible plugins of your choice with the `create` action.
   Switch to the [create](https://github.com/ansible-community/ansible-creator/tree/create) branch and try it out!
+
+## Communication
+
+Refer to the [Get in Touch](https://ansible.readthedocs.io/projects/creator/contributing/#get-in-touch)
+section of the Contributor Guide to find out how to communicate with us.
+
+You can also find more information in the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
+## Contributing
+
+See [Contributing to ansible-creator](https://ansible.readthedocs.io/projects/creator/contributing/).
+
+## Code of Conduct
+
+Please see the official
+[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [Contributing to ansible-creator](https://ansible.readthedocs.io/projects/cr
 
 ## Code of Conduct
 
-Please see the official
+Please see the
 [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## Licensing

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,7 +24,22 @@ All pull requests undergo automated tests. To ensure that your changes align wit
 
 ## Get in touch
 
-Connect with the ansible-creator community through the [GitHub discussions forum](https://github.com/ansible/ansible-creator/discussions). For real-time interactions, join the `#ansible-devtools` IRC channel on libera.chat or the Matrix room [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com). Explore the full list of Ansible IRC and Mailing list options on the Ansible Communication page. Release announcements will be made to the Ansible Announce list. If you encounter security-related concerns, report them via email to [security@ansible.com](mailto:security@ansible.com).
+Connect with the ansible-creator community!
+
+Join the Ansible forum to ask questions, get help, and interact with us.
+
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example the
+  `ansible-creator` or `devtools` tags.
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+
+If you encounter security-related concerns, report them via email to [security@ansible.com](mailto:security@ansible.com).
 
 ## Code of Conduct
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,9 +55,9 @@ extra:
     - icon: simple/matrix
       link: https://matrix.to/#/#devtools:ansible.com
       name: Matrix
-    - icon: fontawesome/solid/comments
-      link: https://github.com/ansible/ansible-creator/discussions
-      name: Discussions
+    - icon: fontawesome/brands/discourse
+      link: https://forum.ansible.com/c/project/7
+      name: Ansible forum
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ansible/ansible-creator
       name: GitHub


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!