### PR TITLE
Split Copier into Walker and Copier steps

### DIFF
--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -138,7 +138,6 @@ class Init:
         copier = Copier(
             output=self.output,
             templar=self._templar,
-            template_data=template_data,
         )
         copier.copy_containers(paths)
 

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -137,7 +137,6 @@ class Init:
 
         copier = Copier(
             output=self.output,
-            templar=self._templar,
         )
         copier.copy_containers(paths)
 

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from ansible_creator.exceptions import CreatorError
 from ansible_creator.templar import Templar
 from ansible_creator.types import TemplateData
-from ansible_creator.utils import Copier
+from ansible_creator.utils import Copier, Walker
 
 
 if TYPE_CHECKING:
@@ -125,14 +125,21 @@ class Init:
             dev_file_name=self.unique_name_in_devfile(),
         )
 
-        copier = Copier(
-            resources=[f"{self._project}_project", *self.common_resources],
+        walker = Walker(
+            resources=(f"{self._project}_project", *self.common_resources),
             resource_id=f"{self._project}_project",
             dest=self._init_path,
             output=self.output,
             templar=self._templar,
             template_data=template_data,
         )
-        copier.copy_containers()
+        paths = walker.collect_paths()
+
+        copier = Copier(
+            output=self.output,
+            templar=self._templar,
+            template_data=template_data,
+        )
+        copier.copy_containers(paths)
 
         self.output.note(f"{self._project} project created at {self._init_path}")

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import os
+import shutil
 
 from dataclasses import dataclass
 from importlib import resources as impl_resources
@@ -111,7 +112,7 @@ class DestinationFile:
         if self.dest.is_file():
             self.dest.unlink()
         elif self.dest.is_dir():
-            self.dest.rmdir()
+            shutil.rmtree(self.dest)
 
 
 @dataclass

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -198,7 +198,7 @@ class Walker:
             source=obj,
             template_data=template_data,
         )
-        self.output.debug(f"Working on {dest_path}")
+        self.output.debug(f"Looking at {dest_path}")
 
         if dest_path.conflicts:
             if dest_path.dest.is_dir():
@@ -304,7 +304,7 @@ class Copier:
             dest_path: The destination path to copy the file to.
         """
         # remove .j2 suffix at destination
-        self.output.debug(msg=f"dest file is {dest_path}")
+        self.output.debug(msg=f"Writing to {dest_path}")
 
         content = dest_path.source.read_text(encoding="utf-8")
         # only render as templates if both of these are provided,

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -154,7 +154,7 @@ class DestinationFile:
 
 
 class FileList(list[DestinationFile]):
-    """list subclass holding DestinationFiles with convenience methods."""
+    """A list subclass holding DestinationFiles with convenience methods."""
 
     def has_conflicts(self) -> bool:
         """Check if any files have conflicts in the destination.

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -16,7 +16,6 @@ from ansible_creator.constants import SKIP_DIRS, SKIP_FILES_TYPES
 
 
 if TYPE_CHECKING:
-
     from ansible_creator.compat import Traversable
     from ansible_creator.output import Output
     from ansible_creator.templar import Templar
@@ -65,8 +64,97 @@ def expand_path(path: str) -> Path:
 
 
 @dataclass
-class Copier:
-    """Configuration for the Copier class.
+class DestinationFile:
+    """Container to hold information about a file to be copied.
+
+    Attributes:
+        destination_path: The path the file will be written to.
+        original_path: The path of the original copy.
+    """
+
+    destination_path: Path
+    original_path: Traversable
+
+    def __str__(self) -> str:
+        """Supports str() on DestinationFile.
+
+        Returns:
+            A string representation of the destination path.
+        """
+        return str(self.destination_path)
+
+    @property
+    def conflicts(self) -> bool:
+        """Check for file conflicts.
+
+        Returns:
+            True if a conflict exists on the destination else False.
+        """
+        if not self.exists():
+            return False
+
+        return not (self.dest_is_dir() and self.is_dir())
+
+    @property
+    def needs_templating(self) -> bool:
+        """Check if templating is required.
+
+        Returns:
+            True if the file needs to be templated else False.
+        """
+        return self.original_path.name.endswith(".j2")
+
+    def exists(self) -> bool:
+        """Check if a file exists at the destination.
+
+        Returns:
+            True if the destination path exists else False.
+        """
+        return self.destination_path.exists()
+
+    def dest_is_dir(self) -> bool:
+        """Check if the destination path is an existing directory.
+
+        Returns:
+            True if the destination path exists and is a directory.
+        """
+        return self.destination_path.exists() and self.destination_path.is_dir()
+
+    def dest_is_file(self) -> bool:
+        """Check if the destination path is an existing file.
+
+        Returns:
+            True if the destination path exists and is a file.
+        """
+        return self.destination_path.exists() and self.destination_path.is_file()
+
+    def is_dir(self) -> bool:
+        """Check if the source path is a directory.
+
+        Returns:
+            True if the source path is a directory.
+        """
+        return self.original_path.is_dir()
+
+    def is_file(self) -> bool:
+        """Check if the source path is a file.
+
+        Returns:
+            True if the source path is a file.
+        """
+        return self.original_path.is_file()
+
+    def remove_existing(self) -> None:
+        """Remove existing files or directories at destination path."""
+        if self.dest_is_file():
+            self.destination_path.unlink()
+        elif self.dest_is_dir():
+            self.destination_path.rmdir()
+
+
+@dataclass
+class Walker:
+    """Configuration for the Walker class.
 
     Attributes:
         resources: List of resource containers to copy.
@@ -74,144 +162,118 @@ class Copier:
         dest: The destination path to copy resources to.
         output: An instance of the Output class.
         template_data: A dictionary containing the original data to render templates with.
-        index: Index of the current resource being copied.
         resource_root: Root path for the resources.
         templar: An instance of the Templar class.
     """
 
-    resources: list[str]
+    resources: tuple[str, ...]
     resource_id: str
     dest: Path
     output: Output
     template_data: TemplateData
-    index: int = 0
     resource_root: str = "ansible_creator.resources"
     templar: Templar | None = None
 
-    @property
-    def resource(self: Copier) -> str:
-        """Return the current resource being copied."""
-        return self.resources[self.index]
-
-    def _recursive_copy(
-        self: Copier,
+    def _recursive_walk(
+        self,
         root: Traversable,
+        resource: str,
         template_data: TemplateData,
-    ) -> None:
-        """Recursively traverses a resource container and copies content to destination.
+    ) -> list[DestinationFile]:
+        """Recursively traverses a resource container looking for content to copy.
 
         Args:
             root: A traversable object representing root of the container to copy.
+            resource: The resource being scanned.
             template_data: A dictionary containing current data to render templates with.
+
+        Returns:
+            A list of paths to be written to.
         """
         self.output.debug(msg=f"current root set to {root}")
 
+        file_list = []
         for obj in root.iterdir():
-            self.each_obj(obj, template_data)
+            file_list.extend(
+                self.each_obj(
+                    obj,
+                    resource=resource,
+                    template_data=template_data,
+                ),
+            )
+        return file_list
 
-    def each_obj(self, obj: Traversable, template_data: TemplateData) -> None:
+    def each_obj(
+        self,
+        obj: Traversable,
+        resource: str,
+        template_data: TemplateData,
+    ) -> list[DestinationFile]:
         """Recursively traverses a resource container and copies content to destination.
 
         Args:
             obj: A traversable object representing the root of the container to copy.
+            resource: The resource to consult for path names.
             template_data: A dictionary containing current data to render templates with.
+
+        Returns:
+            A list of paths.
         """
         # resource names may have a . but directories use / in the path
         dest_name = str(obj).split(
-            self.resource.replace(".", "/") + "/",
+            resource.replace(".", "/") + "/",
             maxsplit=1,
         )[-1]
-        dest_path = self.dest / dest_name
-
         # replace placeholders in destination path with real values
         for key, val in PATH_REPLACERS.items():
-            if key in str(dest_path) and template_data:
-                str_dest_path = str(dest_path)
+            if key in dest_name:
                 repl_val = getattr(template_data, val)
-                dest_path = Path(str_dest_path.replace(key, repl_val))
+                dest_name = dest_name.replace(key, repl_val)
+        dest_name = dest_name.removesuffix(".j2")
 
-        if obj.is_dir():
-            if obj.name in SKIP_DIRS:
-                return
-            self._recursive_copy_dir(obj=obj, dest_path=dest_path, template_data=template_data)
+        dest_path = DestinationFile(self.dest / dest_name, obj)
+        self.output.debug(f"Working on {dest_path}")
 
-        elif obj.is_file():
-            if obj.name.split(".")[-1] in SKIP_FILES_TYPES or obj.name == "__meta__.yml":
-                return
-            self._copy_file(
-                obj=obj,
-                dest_path=dest_path,
-                template_data=template_data,
-            )
+        if dest_path.conflicts:
+            if dest_path.dest_is_dir():
+                self.output.warning(f"{dest_path} already exists and is a directory!")
+            elif dest_path.is_dir():
+                self.output.warning(f"{dest_path} already exists and is a file!")
+            else:
+                self.output.warning(f"{dest_path} will be overwritten!")
 
-    def _copy_file(
-        self,
-        obj: Traversable,
-        dest_path: Path,
-        template_data: TemplateData,
-    ) -> None:
-        """Copy a file to destination.
+        if dest_path.is_dir() and obj.name not in SKIP_DIRS:
+            return [
+                dest_path,
+                *self._recursive_walk(root=obj, resource=resource, template_data=template_data),
+            ]
 
-        Args:
-            obj: A traversable object representing the file to copy.
-            dest_path: The destination path to copy the file to.
-            template_data: A dictionary containing current data to render templates with.
-        """
-        # remove .j2 suffix at destination
-        needs_templating = False
-        if dest_path.suffix == ".j2":
-            dest_path = dest_path.with_suffix("")
-            needs_templating = True
-        dest_file = Path(self.dest) / dest_path
-        self.output.debug(msg=f"dest file is {dest_file}")
+        if (
+            obj.is_file()
+            and obj.name.split(".")[-1] not in SKIP_FILES_TYPES
+            and obj.name != "__meta__.yml"
+        ):
+            return [dest_path]
 
-        content = obj.read_text(encoding="utf-8")
-        # only render as templates if both of these are provided,
-        # and original file suffix was j2
-        if self.templar and template_data and needs_templating:
-            content = self.templar.render_from_content(
-                template=content,
-                data=template_data,
-            )
-        with dest_file.open("w", encoding="utf-8") as df_handle:
-            df_handle.write(content)
+        return []
 
-    def _recursive_copy_dir(
-        self,
-        obj: Traversable,
-        dest_path: Path,
-        template_data: TemplateData,
-    ) -> None:
-        """Recursively copy directories to destination.
+    def _per_container(self, resource: str) -> list[DestinationFile]:
+        """Generate a list of all paths that will be written to for a particular resource.
 
         Args:
-            obj: A traversable object representing the directory to copy.
-            dest_path: The destination path to copy the directory to.
-            template_data: A dictionary containing current data to render templates with.
+            resource: The resource to search through.
+
+        Returns:
+            A list of paths to be written to.
         """
-        dest_path.mkdir(parents=True, exist_ok=True)
-
-        # recursively copy the directory
-        self._recursive_copy(
-            root=obj,
-            template_data=template_data,
-        )
-
-    def _per_container(self: Copier) -> None:
-        """Copy files and directories from a possibly nested source to a destination.
-
-        :param copier_config: Configuration for the Copier class.
-
-        :raises CreatorError: if allow_overwrite is not a list.
-        """
-        msg = f"starting recursive copy with source container '{self.resource}'"
+        msg = f"starting recursive walk with source container '{resource}'"
         self.output.debug(msg)
 
         # Cast the template data to not pollute the original
         template_data = copy.deepcopy(self.template_data)
 
         # Collect and template any resource specific variables
-        meta_file = impl_resources.files(f"{self.resource_root}.{self.resource}") / "__meta__.yml"
+        meta_file = impl_resources.files(f"{self.resource_root}.{resource}") / "__meta__.yml"
         try:
             with meta_file.open("r", encoding="utf-8") as meta_fileh:
                 self.output.debug(
@@ -235,18 +297,76 @@ class Copier:
             else:
                 setattr(template_data, key, value["value"])
 
-        self._recursive_copy(
-            root=impl_resources.files(f"{self.resource_root}.{self.resource}"),
-            template_data=template_data,
+        return self._recursive_walk(
+            impl_resources.files(f"{self.resource_root}.{resource}"),
+            resource,
+            template_data,
         )
 
-    def copy_containers(
-        self: Copier,
+    def collect_paths(self) -> list[DestinationFile]:
+        """Determine paths that will be written to.
+
+        Returns:
+            A list of paths to be written to.
+        """
+        file_list = []
+        for resource in self.resources:
+            file_list.extend(self._per_container(resource))
+
+        return file_list
+
+
+@dataclass
+class Copier:
+    """Configuration for the Copier class.
+
+    Attributes:
+        output: An instance of the Output class.
+        template_data: A dictionary containing the original data to render templates with.
+        templar: An instance of the Templar class.
+    """
+
+    output: Output
+    template_data: TemplateData
+    templar: Templar | None = None
+
+    def _copy_file(
+        self,
+        dest_path: DestinationFile,
+        template_data: TemplateData,
     ) -> None:
+        """Copy a file to destination.
+
+        Args:
+            dest_path: The destination path to copy the file to.
+            template_data: A dictionary containing current data to render templates with.
+        """
+        # remove .j2 suffix at destination
+        self.output.debug(msg=f"dest file is {dest_path}")
+
+        content = dest_path.original_path.read_text(encoding="utf-8")
+        # only render as templates if both of these are provided,
+        # and original file suffix was j2
+        if self.templar and template_data and dest_path.needs_templating:
+            content = self.templar.render_from_content(
+                template=content,
+                data=template_data,
+            )
+        with dest_path.destination_path.open("w", encoding="utf-8") as df_handle:
+            df_handle.write(content)
+
+    def copy_containers(self: Copier, paths: list[DestinationFile]) -> None:
         """Copy multiple containers to destination.
 
-        :param copier_config: Configuration for the Copier class.
+        Args:
+            paths: A list of paths to create in the destination.
         """
-        for i in range(len(self.resources)):
-            self.index = i
-            self._per_container()
+        for path in paths:
+            if path.conflicts:
+                path.remove_existing()
+
+            if path.is_dir():
+                path.destination_path.mkdir(parents=True, exist_ok=True)
+
+            elif path.is_file():
+                self._copy_file(path, self.template_data)

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ansible_creator.types import TemplateData
-from ansible_creator.utils import Copier, expand_path
+from ansible_creator.utils import Copier, Walker, expand_path
 
 
 if TYPE_CHECKING:
@@ -35,13 +35,20 @@ def test_skip_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, output: Outp
         output: Output class object.
     """
     monkeypatch.setattr("ansible_creator.utils.SKIP_DIRS", ["docker"])
-    copier = Copier(
-        resources=["common.devcontainer"],
+
+    walker = Walker(
+        resources=("common.devcontainer",),
         resource_id="common.devcontainer",
         dest=tmp_path,
         output=output,
         template_data=TemplateData(),
     )
-    copier.copy_containers()
+    paths = walker.collect_paths()
+
+    copier = Copier(
+        output=output,
+        template_data=TemplateData(),
+    )
+    copier.copy_containers(paths)
     assert (tmp_path / ".devcontainer" / "podman").exists()
     assert not (tmp_path / ".devcontainer" / "docker").exists()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -77,20 +77,20 @@ def test_overwrite(tmp_path: Path, output: Output) -> None:
     copier.copy_containers(paths)
 
     # Replace podman with a file
-    podman = tmp_path / ".devcontainer" / "podman"
-    shutil.rmtree(podman)
-    podman.write_text("This is an error")
+    podman_dir = tmp_path / ".devcontainer" / "podman"
+    shutil.rmtree(podman_dir)
+    podman_dir.write_text("This is an error")
     # Replace docker devcontainer with a directory
-    docker = tmp_path / ".devcontainer" / "docker" / "devcontainer.json"
-    docker.unlink()
-    docker.mkdir()
+    docker_file = tmp_path / ".devcontainer" / "docker" / "devcontainer.json"
+    docker_file.unlink()
+    docker_file.mkdir()
 
     # Re-walk directory to generate warnings, but not make changes
     paths = walker.collect_paths()
-    assert podman.is_file()
-    assert docker.is_dir()
+    assert podman_dir.is_file()
+    assert docker_file.is_dir()
 
     # Re-copy to overwrite structure
     copier.copy_containers(paths)
-    assert podman.is_dir()
-    assert docker.is_file()
+    assert podman_dir.is_dir()
+    assert docker_file.is_file()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shutil
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -51,3 +53,44 @@ def test_skip_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, output: Outp
     copier.copy_containers(paths)
     assert (tmp_path / ".devcontainer" / "podman").exists()
     assert not (tmp_path / ".devcontainer" / "docker").exists()
+
+
+def test_overwrite(tmp_path: Path, output: Output) -> None:
+    """Test Copier overwriting existing files.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
+    walker = Walker(
+        resources=("common.devcontainer",),
+        resource_id="common.devcontainer",
+        dest=tmp_path,
+        output=output,
+        template_data=TemplateData(),
+    )
+    paths = walker.collect_paths()
+
+    copier = Copier(
+        output=output,
+    )
+    copier.copy_containers(paths)
+
+    # Replace podman with a file
+    podman = tmp_path / ".devcontainer" / "podman"
+    shutil.rmtree(podman)
+    podman.write_text("This is an error")
+    # Replace docker devcontainer with a directory
+    docker = tmp_path / ".devcontainer" / "docker" / "devcontainer.json"
+    docker.unlink()
+    docker.mkdir()
+
+    # Re-walk directory to generate warnings, but not make changes
+    paths = walker.collect_paths()
+    assert podman.is_file()
+    assert docker.is_dir()
+
+    # Re-copy to overwrite structure
+    copier.copy_containers(paths)
+    assert podman.is_dir()
+    assert docker.is_file()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -98,6 +98,7 @@ def test_overwrite(tmp_path: Path, output: Output) -> None:
     assert base_file.read_text() != base_contents
     assert podman_dir.is_file()
     assert docker_file.is_dir()
+    assert paths.has_conflicts()
 
     # Re-copy to overwrite structure
     copier.copy_containers(paths)

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -47,7 +47,6 @@ def test_skip_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, output: Outp
 
     copier = Copier(
         output=output,
-        template_data=TemplateData(),
     )
     copier.copy_containers(paths)
     assert (tmp_path / ".devcontainer" / "podman").exists()

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -104,3 +104,30 @@ def test_overwrite(tmp_path: Path, output: Output) -> None:
     assert base_file.read_text() == base_contents
     assert podman_dir.is_dir()
     assert docker_file.is_file()
+
+
+def test_skip_repeats(tmp_path: Path, output: Output) -> None:
+    """Test Copier skipping existing files.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
+    walker = Walker(
+        resources=("common.devcontainer",),
+        resource_id="common.devcontainer",
+        dest=tmp_path,
+        output=output,
+        template_data=TemplateData(),
+    )
+    paths = walker.collect_paths()
+    assert paths
+
+    copier = Copier(
+        output=output,
+    )
+    copier.copy_containers(paths)
+
+    # Re-walk directory to generate new path list
+    paths = walker.collect_paths()
+    assert not paths


### PR DESCRIPTION
Walker recursively looks for paths that need to be copied over, and returns a list of destination/original path objects

Copier takes that list and does the actual copying.

Notes:
* ~~meta handling is broken right now, I forgot about it~~
* ~~tests have not been touched yet~~
* ~~`--force` is currently a no-op~~
* ~~.gitignore's meta is not getting applied correctly~~
* With `--force` reinstated, there is no good way to access the file conflict handling of Copier
  * Tests have been added

Open Questions:
* Should Walker know to skip existing files that have no changes?
  * Answer: yes

Related issue: https://github.com/ansible/ansible-creator/issues/163