### PR TITLE
Set GITHUB_TOKEN permission in tox jobs

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,3 +17,5 @@ concurrency:
 jobs:
   tox:
     uses: ansible/team-devtools/.github/workflows/tox.yml@main
+    permissions:
+      id-token: write


### PR DESCRIPTION
To fix-> `Error: Codecov: Failed to get OIDC token with url: https://codecov.io./ Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`

https://github.com/ansible/ansible-creator/actions/runs/11161548346/job/31024445852?pr=298