### PR TITLE
Add a check in config to set project type as playbook

### DIFF
--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -47,6 +47,9 @@ class Config:
 
     def __post_init__(self: Config) -> None:
         """Post process config values."""
+        if self.project == "ansible-project":
+            object.__setattr__(self, "project", "playbook")
+
         if self.collection:
             fqcn = self.collection.split(".", maxsplit=1)
             object.__setattr__(self, "namespace", fqcn[0])

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -459,3 +459,25 @@ def test_coming_soon(
     stdout, stderr = capsys.readouterr()
     assert f"`{args}` command is coming soon" in stdout
     assert "Goodbye" in stderr
+
+
+def test_config_post_init(
+    tmp_path: Path,
+    output: Output,
+) -> None:
+    """Test for a check in post_init in Config class.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
+    config = Config(
+        creator_version="24.10.0",
+        output=output,
+        subcommand="init",
+        collection="foo.bar",
+        init_path=str(tmp_path / "test_path"),
+        project="ansible-project",
+    )
+    config.__post_init__()
+    assert config.project == "playbook"


### PR DESCRIPTION
This PR adds a small check in config to set project type as "playbook" from "ansible-project". This is required when args are directly passed to config class (without any interaction with arg_parser)

For example: https://github.com/ansible/ansible-dev-tools/blob/main/src/ansible_dev_tools/resources/server/creator.py#L138-L147

Related PR: https://github.com/ansible/ansible-dev-tools/pull/430