### PR TITLE
Scaffold action plugin through add subcommand

### DIFF
--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -34,10 +34,7 @@ except ImportError:  # pragma: no cover
 
 MIN_COLLECTION_NAME_LEN = 2
 
-COMING_SOON = (
-    "add resource role",
-    "add plugin action",
-)
+COMING_SOON = ("add resource role",)
 
 
 class Parser:
@@ -369,6 +366,7 @@ class Parser:
             formatter_class=CustomHelpFormatter,
         )
         self._add_args_common(parser)
+        self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
 
     def _add_plugin_filter(self, subparser: SubParser[ArgumentParser]) -> None:

--- a/src/ansible_creator/resources/collection_project/plugins/action/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/action/hello_world.py.j2
@@ -13,11 +13,11 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=C0103
 
 from typing import TYPE_CHECKING
-from ansible.plugins.action import ActionBase  # type: ignore
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (  # type: ignore
     AnsibleArgSpecValidator,
 )
 from ansible_collections.ansible.utils.plugins.modules.fact_diff import DOCUMENTATION  # type: ignore
+from ansible.plugins.action import ActionBase  # type: ignore
 
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class ActionModule(ActionBase):  # type: ignore[misc]
     A custom action plugin for Ansible.
     """
 
-    def _check_argspec(self) -> None:
+    def _check_argspec(self, result: dict[str, Any]) -> None:
         aav = AnsibleArgSpecValidator(
             data=self._task.args,
             schema=DOCUMENTATION,
@@ -39,8 +39,8 @@ class ActionModule(ActionBase):  # type: ignore[misc]
         )
         valid, errors, self._task.args = aav.validate()
         if not valid:
-            result["failed"] = True  # type: ignore
-            result["msg"] = errors  # type: ignore
+            result["failed"] = True
+            result["msg"] = errors
 
     def run(
         self,
@@ -65,7 +65,7 @@ class ActionModule(ActionBase):  # type: ignore[misc]
 
         # Example processing logic - Replace this with actual action code
         result = super(ActionModule, self).run(tmp, task_vars)
-        self._check_argspec()
+        self._check_argspec(result)
 
         # Copy the task arguments
         module_args = self._task.args.copy()

--- a/src/ansible_creator/resources/collection_project/plugins/action/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/action/hello_world.py.j2
@@ -1,0 +1,89 @@
+{# action_plugin_template.j2 #}
+{%- set action_name = plugin_name | default("hello_world") -%}
+{%- set author = author | default("Your Name") -%}
+{%- set description = description | default("A custom action plugin for Ansible.") -%}
+{%- set license = license | default("GPL-3.0-or-later") -%}
+# {{ action_name }}.py - {{ description }}
+# Author: {{ author }}
+# License: {{ license }}
+# pylint: disable=E0401
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=C0103
+
+from typing import TYPE_CHECKING
+from ansible.plugins.action import ActionBase  # type: ignore
+
+
+if TYPE_CHECKING:
+    from typing import Optional, Dict, Any
+
+
+DOCUMENTATION = """
+    name: {{ action_name }}
+    author: {{ author }}
+    version_added: "1.0.0"
+    short_description: {{ description }}
+    description:
+      - This is a custom action plugin to provide action functionality.
+    notes:
+      - This is a scaffold template. Customize the plugin to fit your needs.
+"""
+
+EXAMPLES = """
+- name: Example Action Plugin
+  hosts: localhost
+  tasks:
+    - name: Example {{ action_name }} plugin
+      with_prefix:
+        prefix: "Hello, World"
+        msg: "Ansible!"
+"""
+
+
+class ActionModule(ActionBase):  # type: ignore[misc]
+    """
+    Custom Ansible action plugin: {{ action_name }}
+    A custom action plugin for Ansible.
+    """
+
+    def run(
+        self,
+        tmp: Optional[str] = None,
+        task_vars: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Executes the action plugin.
+
+        Args:
+            tmp: Temporary path provided by Ansible for the module execution. Defaults to None.
+            task_vars: Dictionary of task variables available to the plugin. Defaults to None.
+
+        Returns:
+            dict: Result of the action plugin execution.
+        """
+        # Get the task arguments
+        if task_vars is None:
+            task_vars = {}
+        result = {}
+        warnings: list[str] = []
+
+        # Example processing logic - Replace this with actual action code
+        result = super(ActionModule, self).run(tmp, task_vars)
+        module_args = self._task.args.copy()
+        result.update(
+            self._execute_module(
+                module_name="debug",
+                module_args=module_args,
+                task_vars=task_vars,
+                tmp=tmp,
+            ),
+        )
+
+        if warnings:
+            if "warnings" in result:
+                result["warnings"].extend(warnings)
+            else:
+                result["warnings"] = warnings
+        return result

--- a/src/ansible_creator/resources/collection_project/plugins/modules/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/modules/hello_world.py.j2
@@ -1,10 +1,11 @@
 {%- set module_name = plugin_name | default("hello_world") -%}
+{%- set author = author | default("Your Name (@username)") -%}
 # {{ module_name }}.py
 # GNU General Public License v3.0+
 
 DOCUMENTATION = """
     module: {{ module_name }}
-    author: Ansible Core Team
+    author: {{ author }}
     version_added: "1.0.0"
     short_description: A custom action plugin for Ansible.
     description:

--- a/src/ansible_creator/resources/collection_project/plugins/modules/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/modules/hello_world.py.j2
@@ -1,7 +1,9 @@
+{%- set module_name = plugin_name | default("hello_world") -%}
+# {{ module_name }}.py
 # GNU General Public License v3.0+
 
 DOCUMENTATION = """
-    module: hello_world
+    module: {{ module_name }}
     author: Ansible Core Team
     version_added: "1.0.0"
     short_description: A custom action plugin for Ansible.
@@ -27,7 +29,7 @@ EXAMPLES = """
 - name: Example Action Plugin
   hosts: localhost
   tasks:
-    - name: Example hello_world plugin
+    - name: Example {{ module_name }} plugin
       with_prefix:
         prefix: "Hello, World"
         msg: "Ansible!"

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -240,7 +240,7 @@ class Add:
                       destination directory contains files that will be overwritten.
         """
         walker = Walker(
-            resources=(resources),
+            resources=resources,
             resource_id=self._plugin_id,
             dest=plugin_path,
             output=self.output,
@@ -257,6 +257,10 @@ class Add:
                 "\nPlease re-run ansible-creator with --overwrite to continue."
             )
             raise CreatorError(msg)
+
+        # This check is for action plugins (having module file as an additional path)
+        if isinstance(plugin_path, list):
+            plugin_path = plugin_path[0]
 
         if not paths.has_conflicts() or self._force or self._overwrite:
             copier.copy_containers(paths)

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -120,7 +120,7 @@ class Add:
         Raises:
             CreatorError: If unsupported resource type is given.
         """
-        self.output.debug(f"Started copying {self._project} resource to destination")
+        self.output.debug(f"Started adding {self._resource_type} to destination")
 
         # Call the appropriate scaffolding function based on the resource type
         if self._resource_type == "devfile":
@@ -193,8 +193,7 @@ class Add:
         Raises:
             CreatorError: If unsupported plugin type is given.
         """
-        # fix this: The following line needs to be corrected
-        self.output.debug(f"Started copying {self._project} plugin to destination")
+        self.output.debug(f"Started adding {self._plugin_type} plugin to destination")
 
         # Call the appropriate scaffolding function based on the plugin type
         if self._plugin_type == "action":

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -11,7 +11,7 @@ from ansible_creator.constants import GLOBAL_TEMPLATE_VARS
 from ansible_creator.exceptions import CreatorError
 from ansible_creator.templar import Templar
 from ansible_creator.types import TemplateData
-from ansible_creator.utils import Copier, Walker, ask_yes_no
+from ansible_creator.utils import Copier, Walker, ask_yes_no, update_galaxy_dependency
 
 
 if TYPE_CHECKING:
@@ -176,6 +176,7 @@ class Add:
 
         # Call the appropriate scaffolding function based on the plugin type
         if self._plugin_type == "action":
+            update_galaxy_dependency(self._add_path)
             template_data = self._get_plugin_template_data()
             self._perform_action_plugin_scaffold(template_data, plugin_path)
 

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -175,19 +175,59 @@ class Add:
         self.output.debug(f"Started copying {self._project} plugin to destination")
 
         # Call the appropriate scaffolding function based on the plugin type
-        if self._plugin_type in ("action", "filter", "lookup"):
+        if self._plugin_type == "action":
             template_data = self._get_plugin_template_data()
+            self._perform_action_plugin_scaffold(template_data, plugin_path)
+
+        elif self._plugin_type == "filter":
+            template_data = self._get_plugin_template_data()
+            self._perform_filter_plugin_scaffold(template_data, plugin_path)
+
+        elif self._plugin_type == "lookup":
+            template_data = self._get_plugin_template_data()
+            self._perform_lookup_plugin_scaffold(template_data, plugin_path)
 
         else:
             msg = f"Unsupported plugin type: {self._plugin_type}"
             raise CreatorError(msg)
 
-        self._perform_plugin_scaffold(template_data, plugin_path)
+    def _perform_action_plugin_scaffold(
+        self,
+        template_data: TemplateData,
+        plugin_path: Path,
+    ) -> None:
+        resources = (
+            f"collection_project.plugins.{self._plugin_type}",
+            "collection_project.plugins.modules",
+        )
+        self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
-    def _perform_plugin_scaffold(self, template_data: TemplateData, plugin_path: Path) -> None:
+    def _perform_filter_plugin_scaffold(
+        self,
+        template_data: TemplateData,
+        plugin_path: Path,
+    ) -> None:
+        resources = (f"collection_project.plugins.{self._plugin_type}",)
+        self._perform_plugin_scaffold(resources, template_data, plugin_path)
+
+    def _perform_lookup_plugin_scaffold(
+        self,
+        template_data: TemplateData,
+        plugin_path: Path,
+    ) -> None:
+        resources = (f"collection_project.plugins.{self._plugin_type}",)
+        self._perform_plugin_scaffold(resources, template_data, plugin_path)
+
+    def _perform_plugin_scaffold(
+        self,
+        resources: tuple[str, ...],
+        template_data: TemplateData,
+        plugin_path: Path,
+    ) -> None:
         """Perform the actual scaffolding process using the provided template data.
 
         Args:
+            resources: Tuple of resources.
             template_data: TemplateData
             plugin_path: Path where the plugin will be scaffolded.
 
@@ -196,7 +236,7 @@ class Add:
                       destination directory contains files that will be overwritten.
         """
         walker = Walker(
-            resources=(f"collection_project.plugins.{self._plugin_type}",),
+            resources=(resources),
             resource_id=self._plugin_id,
             dest=plugin_path,
             output=self.output,

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -200,7 +200,10 @@ class Add:
             f"collection_project.plugins.{self._plugin_type}",
             "collection_project.plugins.modules",
         )
-        self._perform_plugin_scaffold(resources, template_data, plugin_path)
+        module_path = self._add_path / "plugins" / "modules"
+        module_path.mkdir(parents=True, exist_ok=True)
+        final_plugin_path = [plugin_path, module_path]
+        self._perform_plugin_scaffold(resources, template_data, final_plugin_path)
 
     def _perform_filter_plugin_scaffold(
         self,
@@ -222,7 +225,7 @@ class Add:
         self,
         resources: tuple[str, ...],
         template_data: TemplateData,
-        plugin_path: Path,
+        plugin_path: Path | list[Path],
     ) -> None:
         """Perform the actual scaffolding process using the provided template data.
 

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -174,7 +174,7 @@ class Add:
         self.output.debug(f"Started copying {self._project} plugin to destination")
 
         # Call the appropriate scaffolding function based on the plugin type
-        if self._plugin_type in ("lookup", "filter"):
+        if self._plugin_type in ("action", "filter", "lookup"):
             template_data = self._get_plugin_template_data()
 
         else:

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -416,28 +416,3 @@ def ask_yes_no(question: str) -> bool:
     while answer not in ["y", "n"]:
         answer = input(f"{Color.BRIGHT_WHITE}{question} (y/n){Color.END}: ").lower()
     return answer == "y"
-
-
-def update_galaxy_dependency(collection_path: Path) -> None:
-    """Update galaxy.yml file with the required dependency.
-
-    Args:
-        collection_path: The question to ask.
-    """
-    galaxy_file = collection_path / "galaxy.yml"
-
-    # Load the galaxy.yml file
-    with galaxy_file.open("r", encoding="utf-8") as file:
-        data = yaml.safe_load(file)
-
-    # Ensure the dependencies key exists
-    if "dependencies" not in data:
-        data["dependencies"] = {"ansible.utils": "*"}
-
-    # Empty dependencies key or dependencies key without ansible.utils
-    elif not data["dependencies"] or "ansible.utils" not in data["dependencies"]:
-        data["dependencies"]["ansible.utils"] = "*"
-
-    # Save the updated YAML back to the file
-    with galaxy_file.open("w", encoding="utf-8") as file:
-        yaml.dump(data, file, sort_keys=False)

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -183,7 +183,7 @@ class Walker:
 
     resources: tuple[str, ...]
     resource_id: str
-    dest: Path
+    dest: Path | list[Path]
     output: Output
     template_data: TemplateData
     resource_root: str = "ansible_creator.resources"
@@ -246,10 +246,19 @@ class Walker:
                 dest_name = dest_name.replace(key, repl_val)
         dest_name = dest_name.removesuffix(".j2")
 
-        dest_path = DestinationFile(
-            dest=self.dest / dest_name,
-            source=obj,
-        )
+        if isinstance(self.dest, list):
+            # If self.dest is a list of Paths
+            dest_path = DestinationFile(
+                dest=self.dest[0] / dest_name,
+                source=obj,
+            )
+        else:
+            # If self.dest is a single Path
+            dest_path = DestinationFile(
+                dest=self.dest / dest_name,
+                source=obj,
+            )
+
         self.output.debug(f"Looking at {dest_path}")
 
         if obj.is_file():

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -356,9 +356,8 @@ class Walker:
         """
         file_list = FileList()
         current_index: int = 0
-        for resource in self.resources:
+        for current_index, resource in enumerate(self.resources):
             file_list.extend(self._per_container(resource, current_index))
-            current_index += 1  # noqa: SIM113
 
         return file_list
 

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -419,20 +419,25 @@ def ask_yes_no(question: str) -> bool:
 
 
 def update_galaxy_dependency(collection_path: Path) -> None:
-    """Update galaxy.yml file with the correct dependency.
+    """Update galaxy.yml file with the required dependency.
 
     Args:
         collection_path: The question to ask.
     """
-    galaxy_file_path = collection_path / "galaxy.yml"
+    galaxy_file = collection_path / "galaxy.yml"
 
-    # Read the current content of galaxy.yml
-    with galaxy_file_path.open("r", encoding="utf-8") as file:
-        content = file.read()
+    # Load the galaxy.yml file
+    with galaxy_file.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
 
-    # Update the dependencies field with the new value
-    updated_content = content.replace("{}", "{ansible.utils: '*'}")
+    # Ensure the dependencies key exists
+    if "dependencies" not in data:
+        data["dependencies"] = {"ansible.utils": "*"}
 
-    # Write the updated content back to the file
-    with galaxy_file_path.open("w", encoding="utf-8") as file:
-        file.write(updated_content)
+    # Empty dependencies key or dependencies key without ansible.utils
+    elif not data["dependencies"] or "ansible.utils" not in data["dependencies"]:
+        data["dependencies"]["ansible.utils"] = "*"
+
+    # Save the updated YAML back to the file
+    with galaxy_file.open("w", encoding="utf-8") as file:
+        yaml.dump(data, file, sort_keys=False)

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -193,6 +193,7 @@ class Walker:
         self,
         root: Traversable,
         resource: str,
+        current_index: int,
         template_data: TemplateData,
     ) -> FileList:
         """Recursively traverses a resource container looking for content to copy.
@@ -200,6 +201,7 @@ class Walker:
         Args:
             root: A traversable object representing root of the container to copy.
             resource: The resource being scanned.
+            current_index: Current index in the list of objects.
             template_data: A dictionary containing current data to render templates with.
 
         Returns:
@@ -211,6 +213,7 @@ class Walker:
         for obj in root.iterdir():
             file_list.extend(
                 self.each_obj(
+                    current_index,
                     obj,
                     resource=resource,
                     template_data=template_data,
@@ -220,6 +223,7 @@ class Walker:
 
     def each_obj(
         self,
+        current_index: int,
         obj: Traversable,
         resource: str,
         template_data: TemplateData,
@@ -227,6 +231,7 @@ class Walker:
         """Recursively traverses a resource container and copies content to destination.
 
         Args:
+            current_index: Current index in the list of objects.
             obj: A traversable object representing the root of the container to copy.
             resource: The resource to consult for path names.
             template_data: A dictionary containing current data to render templates with.
@@ -247,9 +252,9 @@ class Walker:
         dest_name = dest_name.removesuffix(".j2")
 
         if isinstance(self.dest, list):
-            # If self.dest is a list of Paths
+            # If self.dest is a list of Path
             dest_path = DestinationFile(
-                dest=self.dest[0] / dest_name,
+                dest=self.dest[current_index] / dest_name,
                 source=obj,
             )
         else:
@@ -277,6 +282,7 @@ class Walker:
                         *self._recursive_walk(
                             root=obj,
                             resource=resource,
+                            current_index=current_index,
                             template_data=template_data,
                         ),
                     ],
@@ -285,15 +291,21 @@ class Walker:
                 return FileList([dest_path])
 
         if obj.is_dir() and obj.name not in SKIP_DIRS:
-            return self._recursive_walk(root=obj, resource=resource, template_data=template_data)
+            return self._recursive_walk(
+                root=obj,
+                resource=resource,
+                current_index=current_index,
+                template_data=template_data,
+            )
 
         return FileList()
 
-    def _per_container(self, resource: str) -> FileList:
+    def _per_container(self, resource: str, current_index: int) -> FileList:
         """Generate a list of all paths that will be written to for a particular resource.
 
         Args:
             resource: The resource to search through.
+            current_index: Current index in the list of objects.
 
         Returns:
             A list of paths to be written to.
@@ -332,6 +344,7 @@ class Walker:
         return self._recursive_walk(
             impl_resources.files(f"{self.resource_root}.{resource}"),
             resource,
+            current_index,
             template_data,
         )
 
@@ -342,8 +355,10 @@ class Walker:
             A list of paths to be written to.
         """
         file_list = FileList()
+        current_index: int = 0
         for resource in self.resources:
-            file_list.extend(self._per_container(resource))
+            file_list.extend(self._per_container(resource, current_index))
+            current_index += 1  # noqa: SIM113
 
         return file_list
 

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -417,3 +417,23 @@ def ask_yes_no(question: str) -> bool:
     while answer not in ["y", "n"]:
         answer = input(f"{Color.BRIGHT_WHITE}{question} (y/n){Color.END}: ").lower()
     return answer == "y"
+
+
+def update_galaxy_dependency(collection_path: Path) -> None:
+    """Update galaxy.yml file with the correct dependency.
+
+    Args:
+        collection_path: The question to ask.
+    """
+    galaxy_file_path = collection_path / "galaxy.yml"
+
+    # Read the current content of galaxy.yml
+    with galaxy_file_path.open("r", encoding="utf-8") as file:
+        content = file.read()
+
+    # Update the dependencies field with the new value
+    updated_content = content.replace("{}", "{ansible.utils: '*'}")
+
+    # Write the updated content back to the file
+    with galaxy_file_path.open("w", encoding="utf-8") as file:
+        file.write(updated_content)

--- a/tests/fixtures/collection/testorg/testcol/plugins/action/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/action/hello_world.py
@@ -8,11 +8,11 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=C0103
 
 from typing import TYPE_CHECKING
-from ansible.plugins.action import ActionBase  # type: ignore
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (  # type: ignore
     AnsibleArgSpecValidator,
 )
 from ansible_collections.ansible.utils.plugins.modules.fact_diff import DOCUMENTATION  # type: ignore
+from ansible.plugins.action import ActionBase  # type: ignore
 
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ class ActionModule(ActionBase):  # type: ignore[misc]
     A custom action plugin for Ansible.
     """
 
-    def _check_argspec(self) -> None:
+    def _check_argspec(self, result: dict[str, Any]) -> None:
         aav = AnsibleArgSpecValidator(
             data=self._task.args,
             schema=DOCUMENTATION,
@@ -34,8 +34,8 @@ class ActionModule(ActionBase):  # type: ignore[misc]
         )
         valid, errors, self._task.args = aav.validate()
         if not valid:
-            result["failed"] = True  # type: ignore
-            result["msg"] = errors  # type: ignore
+            result["failed"] = True
+            result["msg"] = errors
 
     def run(
         self,
@@ -60,7 +60,7 @@ class ActionModule(ActionBase):  # type: ignore[misc]
 
         # Example processing logic - Replace this with actual action code
         result = super(ActionModule, self).run(tmp, task_vars)
-        self._check_argspec()
+        self._check_argspec(result)
 
         # Copy the task arguments
         module_args = self._task.args.copy()

--- a/tests/fixtures/collection/testorg/testcol/plugins/action/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/action/hello_world.py
@@ -1,0 +1,84 @@
+# hello_world.py - A custom action plugin for Ansible.
+# Author: Your Name
+# License: GPL-3.0-or-later
+# pylint: disable=E0401
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=C0103
+
+from typing import TYPE_CHECKING
+from ansible.plugins.action import ActionBase  # type: ignore
+
+
+if TYPE_CHECKING:
+    from typing import Optional, Dict, Any
+
+
+DOCUMENTATION = """
+    name: hello_world
+    author: Your Name
+    version_added: "1.0.0"
+    short_description: A custom action plugin for Ansible.
+    description:
+      - This is a custom action plugin to provide action functionality.
+    notes:
+      - This is a scaffold template. Customize the plugin to fit your needs.
+"""
+
+EXAMPLES = """
+- name: Example Action Plugin
+  hosts: localhost
+  tasks:
+    - name: Example hello_world plugin
+      with_prefix:
+        prefix: "Hello, World"
+        msg: "Ansible!"
+"""
+
+
+class ActionModule(ActionBase):  # type: ignore[misc]
+    """
+    Custom Ansible action plugin: hello_world
+    A custom action plugin for Ansible.
+    """
+
+    def run(
+        self,
+        tmp: Optional[str] = None,
+        task_vars: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Executes the action plugin.
+
+        Args:
+            tmp: Temporary path provided by Ansible for the module execution. Defaults to None.
+            task_vars: Dictionary of task variables available to the plugin. Defaults to None.
+
+        Returns:
+            dict: Result of the action plugin execution.
+        """
+        # Get the task arguments
+        if task_vars is None:
+            task_vars = {}
+        result = {}
+        warnings: list[str] = []
+
+        # Example processing logic - Replace this with actual action code
+        result = super(ActionModule, self).run(tmp, task_vars)
+        module_args = self._task.args.copy()
+        result.update(
+            self._execute_module(
+                module_name="debug",
+                module_args=module_args,
+                task_vars=task_vars,
+                tmp=tmp,
+            ),
+        )
+
+        if warnings:
+            if "warnings" in result:
+                result["warnings"].extend(warnings)
+            else:
+                result["warnings"] = warnings
+        return result

--- a/tests/fixtures/collection/testorg/testcol/plugins/modules/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/modules/hello_world.py
@@ -1,3 +1,4 @@
+# hello_world.py
 # GNU General Public License v3.0+
 
 DOCUMENTATION = """

--- a/tests/fixtures/collection/testorg/testcol/plugins/modules/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/modules/hello_world.py
@@ -3,7 +3,7 @@
 
 DOCUMENTATION = """
     module: hello_world
-    author: Ansible Core Team
+    author: Your Name (@username)
     version_added: "1.0.0"
     short_description: A custom action plugin for Ansible.
     description:


### PR DESCRIPTION
### SUMMARY

- This PR adds support to scaffold  `action` plugins in an existing ansible collection using add subcommand.

- Additionally scaffolds a module file with plugin `DOCUMENTATION` and `EXAMPLES` for corresponding action plugin.

- Also, it creates a sample `hello_world.py` action plugin template when initializing a collection project using init subcommand.


**CLI usage:** 

```
ansible-creator add plugin action your_plugin_name /path/to/your/existing/ansible_collection
```

**Related JIRA**: https://issues.redhat.com/browse/AAP-36202