### PR TITLE
Update scaffolded galaxy file in a collection: Add ansible.utils as a dependency

### DIFF
--- a/src/ansible_creator/resources/collection_project/galaxy.yml.j2
+++ b/src/ansible_creator/resources/collection_project/galaxy.yml.j2
@@ -12,9 +12,13 @@ authors:
 
 description: your collection description
 license_file: LICENSE
+
 # TO-DO: update the tags based on your content type
 tags: ["linux", "tools"]
-dependencies: {}
+
+# TO-DO: maintain this list to reflect the collection's dependencies
+dependencies:
+  "ansible.utils": "*" # note: "*" selects the latest version available
 
 repository: http://example.com/repository
 documentation: http://docs.example.com

--- a/tests/fixtures/collection/testorg/testcol/galaxy.yml
+++ b/tests/fixtures/collection/testorg/testcol/galaxy.yml
@@ -12,9 +12,13 @@ authors:
 
 description: your collection description
 license_file: LICENSE
+
 # TO-DO: update the tags based on your content type
 tags: ["linux", "tools"]
-dependencies: {}
+
+# TO-DO: maintain this list to reflect the collection's dependencies
+dependencies:
+  "ansible.utils": "*" # note: "*" selects the latest version available
 
 repository: http://example.com/repository
 documentation: http://docs.example.com


### PR DESCRIPTION
Related PR: https://github.com/ansible/ansible-creator/pull/348

This change is required to fix `ModuleNotFoundError: No module named 'ansible_collections.ansible.utils'` when running tox-ansible sanity check on a scaffolded collection containing action plugins.

Example of tox-ansible sanity check: `python3 -m tox --ansible -e sanity-py3.13-2.18 --conf tox-ansible.ini`