### PR TITLE
Scaffold a generic module plugin in an existing ansible collection using add subcommand.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,10 +31,9 @@
       "module": "ansible_creator",
       "args": [
         "add",
-        "plugin",
-        "module",
-        "plugin_name",
-        "/home/user/..path/to/your/new_playbook_project"
+        "resource",
+        "devcontainer",
+        "/home/user/..path/to/your/existing_project"
       ],
       "cwd": "${workspaceFolder}/src",
       "justMyCode": false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,9 +31,10 @@
       "module": "ansible_creator",
       "args": [
         "add",
-        "resource",
-        "devcontainer",
-        "/home/user/..path/to/your/existing_project"
+        "plugin",
+        "module",
+        "plugin_name",
+        "/Users/shvenkat/trial"
       ],
       "cwd": "${workspaceFolder}/src",
       "justMyCode": false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,7 @@
         "plugin",
         "module",
         "plugin_name",
-        "/Users/shvenkat/trial"
+        "/home/user/..path/to/your/new_playbook_project"
       ],
       "cwd": "${workspaceFolder}/src",
       "justMyCode": false

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -331,22 +331,22 @@ $ ansible-creator add resource devfile /home/user/..path/to/your/existing_projec
 
 This command will scaffold the devfile.yaml file at `/home/user/..path/to/your/existing_project`
 
-### Add support to scaffold a plugin in an existing project
+### Add support to scaffold plugins in an existing ansible collection
 
-The `add plugin` command enables you to add a plugin to an already existing project. Use the following command template:
+The `add plugin` command enables you to add a plugin to an to an existing collection project. Use the following command template:
 
 ```console
-$ ansible-creator add plugin <plugin-type> <path>
+$ ansible-creator add plugin <plugin-type> <plugin-name> <collection-path>
 ```
 
 #### Positional Arguments
 
-| Parameter | Description                                                 |
-| --------- | ----------------------------------------------------------- |
-| action    | Add an action plugin to an existing Ansible project.        |
-| filter    | Add a filter plugin to an existing Ansible project.         |
-| lookup    | Add a lookup plugin to an existing Ansible project.         |
-| module    | Add a generic module plugin to an existing Ansible project. |
+| Parameter | Description                                                    |
+| --------- | -------------------------------------------------------------- |
+| action    | Add an action plugin to an existing Ansible Collection.        |
+| filter    | Add a filter plugin to an existing Ansible Collection.         |
+| lookup    | Add a lookup plugin to an existing Ansible Collection.         |
+| module    | Add a generic module plugin to an existing Ansible Collection. |
 
 #### Example
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -330,3 +330,28 @@ $ ansible-creator add resource devfile /home/user/..path/to/your/existing_projec
 ```
 
 This command will scaffold the devfile.yaml file at `/home/user/..path/to/your/existing_project`
+
+### Add support to scaffold a plugin in an existing project
+
+The `add plugin` command enables you to add a plugin to an already existing project. Use the following command template:
+
+```console
+$ ansible-creator add plugin <plugin-type> <path>
+```
+
+#### Positional Arguments
+
+| Parameter    | Description                                                |
+| ------------ | ---------------------------------------------------------- |
+| action       | Add an action plugin to an existing Ansible project.       |
+| filter       | Add a filter plugin to an existing Ansible project.        |
+| lookup       | Add a lookup plugin to an existing Ansible project.        |
+| module       | Add a generic module plugin to an existing Ansible project.|
+
+#### Example
+
+```console
+$ ansible-creator add plugin module module_name /home/user/..path/to/your/existing_project
+```
+
+This command will scaffold the devfile.yaml file at `/home/user/..path/to/your/existing_project`

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -341,12 +341,12 @@ $ ansible-creator add plugin <plugin-type> <path>
 
 #### Positional Arguments
 
-| Parameter    | Description                                                |
-| ------------ | ---------------------------------------------------------- |
-| action       | Add an action plugin to an existing Ansible project.       |
-| filter       | Add a filter plugin to an existing Ansible project.        |
-| lookup       | Add a lookup plugin to an existing Ansible project.        |
-| module       | Add a generic module plugin to an existing Ansible project.|
+| Parameter | Description                                                 |
+| --------- | ----------------------------------------------------------- |
+| action    | Add an action plugin to an existing Ansible project.        |
+| filter    | Add a filter plugin to an existing Ansible project.         |
+| lookup    | Add a lookup plugin to an existing Ansible project.         |
+| module    | Add a generic module plugin to an existing Ansible project. |
 
 #### Example
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -351,7 +351,7 @@ $ ansible-creator add plugin <plugin-type> <plugin-name> <collection-path>
 #### Example
 
 ```console
-$ ansible-creator add plugin module module_name /home/user/..path/to/your/existing_project
+$ ansible-creator add plugin module plugin_name /home/user/..path/to/your/existing_project
 ```
 
-This command will scaffold the devfile.yaml file at `/home/user/..path/to/your/existing_project`
+This command will scaffold a generic module plugin at `/home/user/..path/to/your/existing_project`

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -333,7 +333,7 @@ This command will scaffold the devfile.yaml file at `/home/user/..path/to/your/e
 
 ### Add support to scaffold plugins in an existing ansible collection
 
-The `add plugin` command enables you to add a plugin to an to an existing collection project. Use the following command template:
+The `add plugin` command enables you to add a plugin to an existing collection project. Use the following command template:
 
 ```console
 $ ansible-creator add plugin <plugin-type> <plugin-name> <collection-path>
@@ -351,7 +351,7 @@ $ ansible-creator add plugin <plugin-type> <plugin-name> <collection-path>
 #### Example
 
 ```console
-$ ansible-creator add plugin module plugin_name /home/user/..path/to/your/existing_project
+$ ansible-creator add plugin module test_plugin /home/user/..path/to/your/existing_project
 ```
 
 This command will scaffold a generic module plugin at `/home/user/..path/to/your/existing_project`

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -353,7 +353,7 @@ class Parser:
         self._add_plugin_action(subparser=subparser)
         self._add_plugin_filter(subparser=subparser)
         self._add_plugin_lookup(subparser=subparser)
-        self._add_plugin_modules(subparser=subparser)
+        self._add_plugin_module(subparser=subparser)
 
     def _add_plugin_action(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add an action plugin to an existing Ansible collection project.
@@ -385,7 +385,7 @@ class Parser:
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
 
-    def _add_plugin_modules(self, subparser: SubParser[ArgumentParser]) -> None:
+    def _add_plugin_module(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add a module plugin to an existing Ansible collection project.
 
         Args:

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -385,21 +385,6 @@ class Parser:
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
 
-    def _add_plugin_module(self, subparser: SubParser[ArgumentParser]) -> None:
-        """Add a module plugin to an existing Ansible collection project.
-
-        Args:
-            subparser: The subparser to add module plugin to
-        """
-        parser = subparser.add_parser(
-            "module",
-            help="Add a module plugin to an existing Ansible collection.",
-            formatter_class=CustomHelpFormatter,
-        )
-        self._add_args_common(parser)
-        self._add_overwrite(parser)
-        self._add_args_plugin_common(parser)
-
     def _add_plugin_lookup(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add a lookup plugin to an existing Ansible collection project.
 
@@ -415,6 +400,22 @@ class Parser:
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
 
+
+    def _add_plugin_module(self, subparser: SubParser[ArgumentParser]) -> None:
+        """Add a module plugin to an existing Ansible collection project.
+
+        Args:
+            subparser: The subparser to add module plugin to
+        """
+        parser = subparser.add_parser(
+            "module",
+            help="Add a module plugin to an existing Ansible collection.",
+            formatter_class=CustomHelpFormatter,
+        )
+        self._add_args_common(parser)
+        self._add_overwrite(parser)
+        self._add_args_plugin_common(parser)
+        
     def _add_overwrite(self, parser: ArgumentParser) -> None:
         """Add overwrite and no-overwrite arguments to the parser.
 

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -231,7 +231,31 @@ class Parser:
         self._add_resource_devfile(subparser=subparser)
         self._add_resource_role(subparser=subparser)
         self._add_resource_execution_env(subparser=subparser)
+        #self._add_resource_module(subparser=subparser)
+    
+    def _add_resource_module(self, subparser: SubParser[ArgumentParser]) -> None:
+        """Add generic modules files to an existing Ansible project.
 
+        Args:
+            subparser: The subparser to add generic modules files to
+        """
+        parser = subparser.add_parser(
+            "module",
+            help="Add a generic module to an existing Ansible collection.",
+            formatter_class=CustomHelpFormatter,
+        )
+        parser.add_argument(
+            "module_name",
+            help="The name of the module to add.",
+        )
+        parser.add_argument(
+            "path",
+            default="./",
+            help="The path to the Ansible collection. The default is the current working directory.",
+        )
+        self._add_overwrite(parser)
+        self._add_args_common(parser)
+        
     def _add_resource_devcontainer(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add devcontainer files to an existing Ansible project.
 
@@ -353,6 +377,7 @@ class Parser:
         self._add_plugin_action(subparser=subparser)
         self._add_plugin_filter(subparser=subparser)
         self._add_plugin_lookup(subparser=subparser)
+        self._add_plugin_modules(subparser=subparser)
 
     def _add_plugin_action(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add an action plugin to an existing Ansible collection project.
@@ -384,6 +409,21 @@ class Parser:
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
 
+    def _add_plugin_modules(self, subparser: SubParser[ArgumentParser]) -> None:
+        """Add a module plugin to an existing Ansible collection project.
+
+        Args:
+            subparser: The subparser to add module plugin to
+        """
+        parser = subparser.add_parser(
+            "module",
+            help="Add a module plugin to an existing Ansible collection.",
+            formatter_class=CustomHelpFormatter,
+        )
+        self._add_args_common(parser)
+        self._add_overwrite(parser)
+        self._add_args_plugin_common(parser)
+    
     def _add_plugin_lookup(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add a lookup plugin to an existing Ansible collection project.
 

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -400,7 +400,6 @@ class Parser:
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
 
-
     def _add_plugin_module(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add a module plugin to an existing Ansible collection project.
 
@@ -415,7 +414,7 @@ class Parser:
         self._add_args_common(parser)
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
-        
+
     def _add_overwrite(self, parser: ArgumentParser) -> None:
         """Add overwrite and no-overwrite arguments to the parser.
 

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -231,7 +231,7 @@ class Parser:
         self._add_resource_devfile(subparser=subparser)
         self._add_resource_role(subparser=subparser)
         self._add_resource_execution_env(subparser=subparser)
-        
+
     def _add_resource_devcontainer(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add devcontainer files to an existing Ansible project.
 
@@ -399,7 +399,7 @@ class Parser:
         self._add_args_common(parser)
         self._add_overwrite(parser)
         self._add_args_plugin_common(parser)
-    
+
     def _add_plugin_lookup(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add a lookup plugin to an existing Ansible collection project.
 

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -231,30 +231,6 @@ class Parser:
         self._add_resource_devfile(subparser=subparser)
         self._add_resource_role(subparser=subparser)
         self._add_resource_execution_env(subparser=subparser)
-        #self._add_resource_module(subparser=subparser)
-    
-    def _add_resource_module(self, subparser: SubParser[ArgumentParser]) -> None:
-        """Add generic modules files to an existing Ansible project.
-
-        Args:
-            subparser: The subparser to add generic modules files to
-        """
-        parser = subparser.add_parser(
-            "module",
-            help="Add a generic module to an existing Ansible collection.",
-            formatter_class=CustomHelpFormatter,
-        )
-        parser.add_argument(
-            "module_name",
-            help="The name of the module to add.",
-        )
-        parser.add_argument(
-            "path",
-            default="./",
-            help="The path to the Ansible collection. The default is the current working directory.",
-        )
-        self._add_overwrite(parser)
-        self._add_args_common(parser)
         
     def _add_resource_devcontainer(self, subparser: SubParser[ArgumentParser]) -> None:
         """Add devcontainer files to an existing Ansible project.

--- a/src/ansible_creator/resources/collection_project/plugins/module/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/module/hello_world.py.j2
@@ -1,0 +1,65 @@
+{# module_plugin_template.j2 #}
+{%- set module_name = plugin_name | default("hello_world") -%}
+{%- set author = author | default("Your Name") -%}
+{%- set description = description | default("A custom module plugin for Ansible.") -%}
+{%- set license = license | default("GPL-3.0-or-later") -%}
+# {{ module_name }}.py - {{ description }}
+# Author: {{ author }}
+# License: {{ license }}
+
+from __future__ import absolute_import, annotations, division, print_function
+
+
+__metaclass__ = type  # pylint: disable=C0103
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+
+DOCUMENTATION = """
+    name: {{ module_name }}
+    author: {{ author }}
+    version_added: "1.0.0"
+    short_description: {{ description }}
+    description:
+      - This is a demo module plugin designed to return Hello message.
+    options:
+      name:
+        description: Value specified here is appended to the Hello message.
+        type: str
+"""
+
+EXAMPLES = """
+# {{ module_name }} module example
+{% raw %}
+- name: Display a hello message
+  ansible.builtin.debug:
+    msg: "{{ 'ansible-creator' {%- endraw %} | {{ module_name }} }}"
+"""
+
+
+def _hello_world(name: str) -> str:
+    """Returns Hello message.
+
+    Args:
+        name: The name to greet.
+
+    Returns:
+        str: The greeting message.
+    """
+    return "Hello, " + name
+
+
+class ModuleModule:
+    """module plugin."""
+
+    def modules(self) -> dict[str, Callable[[str], str]]:
+        """Map module plugin names to their functions.
+
+        Returns:
+            dict: The module plugin functions.
+        """
+        return {"{{ module_name }}": _hello_world}

--- a/src/ansible_creator/resources/collection_project/plugins/sample_module/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/sample_module/hello_world.py.j2
@@ -1,6 +1,6 @@
 {# module_plugin_template.j2 #}
 {%- set module_name = plugin_name | default("hello_world") -%}
-{%- set author = author | default("Your Name") -%}
+{%- set author = author |  default("Your Name (@username)") -%}
 {%- set description = description | default("A custom module plugin for Ansible.") -%}
 {%- set license = license | default("GPL-3.0-or-later") -%}
 # {{ module_name }}.py - {{ description }}

--- a/src/ansible_creator/resources/collection_project/plugins/sample_module/hello_world.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/sample_module/hello_world.py.j2
@@ -53,7 +53,7 @@ def _hello_world(name: str) -> str:
     return "Hello, " + name
 
 
-class ModuleModule:
+class SampleModule:
     """module plugin."""
 
     def modules(self) -> dict[str, Callable[[str], str]]:

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -244,7 +244,7 @@ class Add:
     ) -> None:
         resources = (f"collection_project.plugins.{self._plugin_type}",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
-    
+
     def _perform_lookup_plugin_scaffold(
         self,
         template_data: TemplateData,

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -208,6 +208,7 @@ class Add:
         elif self._plugin_type == "lookup":
             template_data = self._get_plugin_template_data()
             self._perform_lookup_plugin_scaffold(template_data, plugin_path)
+
         elif self._plugin_type == "module":
             template_data = self._get_plugin_template_data()
             self._perform_module_plugin_scaffold(template_data, plugin_path)
@@ -250,10 +251,10 @@ class Add:
         template_data: TemplateData,
         plugin_path: Path,
     ) -> None:
-        module_path = self._add_path / "plugins" / "sample_module"
-        module_path.mkdir(parents=True, exist_ok=True)
+        plugin_path = self._add_path / "plugins" / "sample_module"
+        plugin_path.mkdir(parents=True, exist_ok=True)
         resources = ("collection_project.plugins.sample_module",)
-        self._perform_plugin_scaffold(resources, template_data, module_path)
+        self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
     def _perform_plugin_scaffold(
         self,

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -210,7 +210,9 @@ class Add:
             self._perform_lookup_plugin_scaffold(template_data, plugin_path)
         elif self._plugin_type == "module":
             template_data = self._get_plugin_template_data()
-            self._perform_module_plugin_scaffold(template_data, plugin_path)
+            module_path=self._add_path / "plugins" / "sample_module"
+            module_path.mkdir(parents=True, exist_ok=True)
+            self._perform_module_plugin_scaffold(template_data, module_path)
         else:
             msg = f"Unsupported plugin type: {self._plugin_type}"
             raise CreatorError(msg)
@@ -242,7 +244,7 @@ class Add:
         template_data: TemplateData,
         plugin_path: Path,
     ) -> None:
-        resources = (f"collection_project.plugins.{self._plugin_type}",)
+        resources = (f"collection_project.plugins.sample_module",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
     def _perform_lookup_plugin_scaffold(

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -210,7 +210,7 @@ class Add:
             self._perform_lookup_plugin_scaffold(template_data, plugin_path)
         elif self._plugin_type == "module":
             template_data = self._get_plugin_template_data()
-            module_path=self._add_path / "plugins" / "sample_module"
+            module_path = self._add_path / "plugins" / "sample_module"
             module_path.mkdir(parents=True, exist_ok=True)
             self._perform_module_plugin_scaffold(template_data, module_path)
         else:
@@ -244,7 +244,7 @@ class Add:
         template_data: TemplateData,
         plugin_path: Path,
     ) -> None:
-        resources = (f"collection_project.plugins.sample_module",)
+        resources = ("collection_project.plugins.sample_module",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
     def _perform_lookup_plugin_scaffold(

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -210,9 +210,7 @@ class Add:
             self._perform_lookup_plugin_scaffold(template_data, plugin_path)
         elif self._plugin_type == "module":
             template_data = self._get_plugin_template_data()
-            module_path = self._add_path / "plugins" / "sample_module"
-            module_path.mkdir(parents=True, exist_ok=True)
-            self._perform_module_plugin_scaffold(template_data, module_path)
+            self._perform_module_plugin_scaffold(template_data, plugin_path)
         else:
             msg = f"Unsupported plugin type: {self._plugin_type}"
             raise CreatorError(msg)
@@ -252,8 +250,10 @@ class Add:
         template_data: TemplateData,
         plugin_path: Path,
     ) -> None:
+        module_path = self._add_path / "plugins" / "sample_module"
+        module_path.mkdir(parents=True, exist_ok=True)
         resources = ("collection_project.plugins.sample_module",)
-        self._perform_plugin_scaffold(resources, template_data, plugin_path)
+        self._perform_plugin_scaffold(resources, template_data, module_path)
 
     def _perform_plugin_scaffold(
         self,

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -239,14 +239,6 @@ class Add:
         resources = (f"collection_project.plugins.{self._plugin_type}",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
-    def _perform_module_plugin_scaffold(
-        self,
-        template_data: TemplateData,
-        plugin_path: Path,
-    ) -> None:
-        resources = ("collection_project.plugins.sample_module",)
-        self._perform_plugin_scaffold(resources, template_data, plugin_path)
-
     def _perform_lookup_plugin_scaffold(
         self,
         template_data: TemplateData,
@@ -255,6 +247,14 @@ class Add:
         resources = (f"collection_project.plugins.{self._plugin_type}",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
+    def _perform_module_plugin_scaffold(
+        self,
+        template_data: TemplateData,
+        plugin_path: Path,
+    ) -> None:
+        resources = ("collection_project.plugins.sample_module",)
+        self._perform_plugin_scaffold(resources, template_data, plugin_path)
+        
     def _perform_plugin_scaffold(
         self,
         resources: tuple[str, ...],

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -208,7 +208,9 @@ class Add:
         elif self._plugin_type == "lookup":
             template_data = self._get_plugin_template_data()
             self._perform_lookup_plugin_scaffold(template_data, plugin_path)
-
+        elif self._plugin_type == "module":
+            template_data = self._get_plugin_template_data()
+            self._perform_module_plugin_scaffold(template_data, plugin_path)
         else:
             msg = f"Unsupported plugin type: {self._plugin_type}"
             raise CreatorError(msg)
@@ -235,6 +237,14 @@ class Add:
         resources = (f"collection_project.plugins.{self._plugin_type}",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
 
+    def _perform_module_plugin_scaffold(
+        self,
+        template_data: TemplateData,
+        plugin_path: Path,
+    ) -> None:
+        resources = (f"collection_project.plugins.{self._plugin_type}",)
+        self._perform_plugin_scaffold(resources, template_data, plugin_path)
+    
     def _perform_lookup_plugin_scaffold(
         self,
         template_data: TemplateData,

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -254,7 +254,7 @@ class Add:
     ) -> None:
         resources = ("collection_project.plugins.sample_module",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
-        
+
     def _perform_plugin_scaffold(
         self,
         resources: tuple[str, ...],

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -211,6 +211,8 @@ class Add:
 
         elif self._plugin_type == "module":
             template_data = self._get_plugin_template_data()
+            plugin_path = self._add_path / "plugins" / "sample_module"
+            plugin_path.mkdir(parents=True, exist_ok=True)
             self._perform_module_plugin_scaffold(template_data, plugin_path)
         else:
             msg = f"Unsupported plugin type: {self._plugin_type}"
@@ -251,8 +253,6 @@ class Add:
         template_data: TemplateData,
         plugin_path: Path,
     ) -> None:
-        plugin_path = self._add_path / "plugins" / "sample_module"
-        plugin_path.mkdir(parents=True, exist_ok=True)
         resources = ("collection_project.plugins.sample_module",)
         self._perform_plugin_scaffold(resources, template_data, plugin_path)
 

--- a/tests/fixtures/collection/testorg/testcol/plugins/sample_module/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/sample_module/hello_world.py
@@ -1,0 +1,35 @@
+# hello_world.py
+# GNU General Public License v3.0+
+
+DOCUMENTATION = """
+    module: hello_world
+    author: Your Name (@username)
+    version_added: "1.0.0"
+    short_description: A custom module plugin for Ansible.
+    description:
+      - This is a custom module plugin to provide module functionality.
+    options:
+      prefix:
+        description:
+          - A string that is added as a prefix to the message passed to the module.
+        type: str
+      msg:
+        description: The message to display in the output.
+        type: str
+      with_prefix:
+        description:
+          - A boolean flag indicating whether to include the prefix in the message.
+        type: bool
+    notes:
+      - This is a scaffold template. Customize the plugin to fit your needs.
+"""
+
+EXAMPLES = """
+- name: Example Module Plugin
+  hosts: localhost
+  tasks:
+    - name: Example hello_world plugin
+      with_prefix:
+        prefix: "Hello, World"
+        msg: "Ansible!"
+"""

--- a/tests/fixtures/collection/testorg/testcol/plugins/sample_module/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/sample_module/hello_world.py
@@ -1,5 +1,5 @@
 # hello_world.py - A custom module plugin for Ansible.
-# Author: Your Name
+# Author: Your Name (@username)
 # License: GPL-3.0-or-later
 
 from __future__ import absolute_import, annotations, division, print_function
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 DOCUMENTATION = """
     name: hello_world
-    author: Your Name
+    author: Your Name (@username)
     version_added: "1.0.0"
     short_description: A custom module plugin for Ansible.
     description:

--- a/tests/fixtures/collection/testorg/testcol/plugins/sample_module/hello_world.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/sample_module/hello_world.py
@@ -1,35 +1,60 @@
-# hello_world.py
-# GNU General Public License v3.0+
+# hello_world.py - A custom module plugin for Ansible.
+# Author: Your Name
+# License: GPL-3.0-or-later
+
+from __future__ import absolute_import, annotations, division, print_function
+
+
+__metaclass__ = type  # pylint: disable=C0103
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Callable
+
 
 DOCUMENTATION = """
-    module: hello_world
-    author: Your Name (@username)
+    name: hello_world
+    author: Your Name
     version_added: "1.0.0"
     short_description: A custom module plugin for Ansible.
     description:
-      - This is a custom module plugin to provide module functionality.
+      - This is a demo module plugin designed to return Hello message.
     options:
-      prefix:
-        description:
-          - A string that is added as a prefix to the message passed to the module.
+      name:
+        description: Value specified here is appended to the Hello message.
         type: str
-      msg:
-        description: The message to display in the output.
-        type: str
-      with_prefix:
-        description:
-          - A boolean flag indicating whether to include the prefix in the message.
-        type: bool
-    notes:
-      - This is a scaffold template. Customize the plugin to fit your needs.
 """
 
 EXAMPLES = """
-- name: Example Module Plugin
-  hosts: localhost
-  tasks:
-    - name: Example hello_world plugin
-      with_prefix:
-        prefix: "Hello, World"
-        msg: "Ansible!"
+# hello_world module example
+
+- name: Display a hello message
+  ansible.builtin.debug:
+    msg: "{{ 'ansible-creator' | hello_world }}"
 """
+
+
+def _hello_world(name: str) -> str:
+    """Returns Hello message.
+
+    Args:
+        name: The name to greet.
+
+    Returns:
+        str: The greeting message.
+    """
+    return "Hello, " + name
+
+
+class SampleModule:
+    """module plugin."""
+
+    def modules(self) -> dict[str, Callable[[str], str]]:
+        """Map module plugin names to their functions.
+
+        Returns:
+            dict: The module plugin functions.
+        """
+        return {"hello_world": _hello_world}

--- a/tests/units/test_add.py
+++ b/tests/units/test_add.py
@@ -674,6 +674,81 @@ def test_run_success_add_plugin_action(
     cmp_result2 = cmp(expected_module_file, effective_module_file, shallow=False)
     assert cmp_result1, cmp_result2
 
+def test_run_success_add_plugin_module(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test Add.run().
+
+    Successfully add plugin to path
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Add class object.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    cli_args["plugin_type"] = "module"
+    add = Add(
+        Config(**cli_args),
+    )
+
+    # Mock the "_check_collection_path" method
+    def mock_check_collection_path() -> None:
+        """Mock function to skip checking collection path."""
+
+    monkeypatch.setattr(
+        Add,
+        "_check_collection_path",
+        staticmethod(mock_check_collection_path),
+    )
+    add.run()
+    result = capsys.readouterr().out
+    assert re.search("Note: Lookup plugin added to", result) is not None
+
+    expected_file = tmp_path / "plugins" / "sample_module" / "hello_world.py"
+    effective_file = (
+        FIXTURES_DIR
+        / "collection"
+        / "testorg"
+        / "testcol"
+        / "plugins"
+        / "sample_module"
+        / "hello_world.py"
+    )
+    cmp_result = cmp(expected_file, effective_file, shallow=False)
+    assert cmp_result
+
+    conflict_file = tmp_path / "plugins" / "sample_module" / "hello_world.py"
+    conflict_file.write_text("Author: Your Name")
+
+    # expect a CreatorError when the response to overwrite is no.
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    fail_msg = (
+        "The destination directory contains files that will be overwritten."
+        " Please re-run ansible-creator with --overwrite to continue."
+    )
+    with pytest.raises(
+        CreatorError,
+        match=fail_msg,
+    ):
+        add.run()
+
+    # expect a warning followed by lookup plugin addition msg
+    # when response to overwrite is yes.
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    add.run()
+    result = capsys.readouterr().out
+    assert (
+        re.search(
+            "already exists",
+            result,
+        )
+        is not None
+    ), result
+    assert re.search("Note: Lookup plugin added to", result) is not None
 
 def test_run_error_plugin_no_overwrite(
     capsys: pytest.CaptureFixture[str],

--- a/tests/units/test_add.py
+++ b/tests/units/test_add.py
@@ -707,7 +707,7 @@ def test_run_success_add_plugin_module(
     )
     add.run()
     result = capsys.readouterr().out
-    assert re.search("Note: Lookup plugin added to", result) is not None
+    assert re.search("Note: Module plugin added to", result) is not None
 
     expected_file = tmp_path / "plugins" / "sample_module" / "hello_world.py"
     effective_file = (

--- a/tests/units/test_add.py
+++ b/tests/units/test_add.py
@@ -674,6 +674,7 @@ def test_run_success_add_plugin_action(
     cmp_result2 = cmp(expected_module_file, effective_module_file, shallow=False)
     assert cmp_result1, cmp_result2
 
+
 def test_run_success_add_plugin_module(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
@@ -749,6 +750,7 @@ def test_run_success_add_plugin_module(
         is not None
     ), result
     assert re.search("Note: Lookup plugin added to", result) is not None
+
 
 def test_run_error_plugin_no_overwrite(
     capsys: pytest.CaptureFixture[str],

--- a/tests/units/test_add.py
+++ b/tests/units/test_add.py
@@ -737,7 +737,7 @@ def test_run_success_add_plugin_module(
     ):
         add.run()
 
-    # expect a warning followed by lookup plugin addition msg
+    # expect a warning followed by module plugin addition msg
     # when response to overwrite is yes.
     monkeypatch.setattr("builtins.input", lambda _: "y")
     add.run()

--- a/tests/units/test_add.py
+++ b/tests/units/test_add.py
@@ -749,7 +749,7 @@ def test_run_success_add_plugin_module(
         )
         is not None
     ), result
-    assert re.search("Note: Lookup plugin added to", result) is not None
+    assert re.search("Note: Module plugin added to", result) is not None
 
 
 def test_run_error_plugin_no_overwrite(


### PR DESCRIPTION
**SUMMARY**

This PR adds support to scaffold module plugins in an existing ansible collection using add subcommand.

A new "module" subdirectory has been created under the plugins directory.

**CLI usage:**

`ansible-creator add plugin module your_module_name /path/to/your/existing/ansible_collection
`

Related JIRA: https://issues.redhat.com/browse/AAP-36203

