### PR TITLE
Workaround for dependabot improper python version

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+#!/bin/bash
+# PWD is supposed to be the directory container the .envrc file based on the
+# specs. This trick should isolate our testing from user environment.
+ANSIBLE_HOME=$PWD/.ansible
+ANSIBLE_CONFIG=$PWD/ansible.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,6 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
 .venv
 env/
 venv/

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_disable_tools = ["python"]


### PR DESCRIPTION
Due to https://github.com/dependabot/dependabot-core/issues/1455
we are forced to add a `.python-version` file so dependabot will not use unsupported older python when running.

Still, we need to reconfigure `mise` to tell it to ignore this file.

Related: https://github.com/ansible/ansible-compat/pull/479
Related: AAP-43336
