### PR TITLE
Refactor plugin tests in test_add.py

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -24,7 +24,6 @@ tests/units/test_add.py
     DOC502: Function `test_error_invalid_collection_path` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_error_unsupported_resource_type` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_success_add_devcontainer` has a "Raises" section in the docstring, but there are not "raise" statements in the body
-    DOC502: Function `test_run_success_add_plugin_action` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_error_plugin_no_overwrite` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_error_unsupported_plugin_type` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_success_add_execution_env` has a "Raises" section in the docstring, but there are not "raise" statements in the body

--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -24,11 +24,7 @@ tests/units/test_add.py
     DOC502: Function `test_error_invalid_collection_path` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_error_unsupported_resource_type` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_success_add_devcontainer` has a "Raises" section in the docstring, but there are not "raise" statements in the body
-    DOC502: Function `test_run_success_add_plugin_filter` has a "Raises" section in the docstring, but there are not "raise" statements in the body
-    DOC502: Function `test_run_success_add_plugin_lookup` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_success_add_plugin_action` has a "Raises" section in the docstring, but there are not "raise" statements in the body
-    DOC502: Function `test_run_success_add_plugin_module` has a "Raises" section in the docstring, but there are not "raise" statements in the body
-    DOC502: Function `test_run_success_add_plugin_test` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_error_plugin_no_overwrite` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_error_unsupported_plugin_type` has a "Raises" section in the docstring, but there are not "raise" statements in the body
     DOC502: Function `test_run_success_add_execution_env` has a "Raises" section in the docstring, but there are not "raise" statements in the body


### PR DESCRIPTION
### SUMMARY

This PR refactors `test_add.py` file to address the following objectives:

- Group related test scenarios: Use `pytest.mark.parametrize` to reuse shared logic and reduce boilerplate code.
- Remove Pylint Suppression: Eliminate the need for suppressing the C0302 (too-many-lines) warning.
 

JIRA: [AAP-44157](https://issues.redhat.com/browse/AAP-44157)
Closes: https://github.com/ansible/ansible-creator/issues/398