### PR TITLE
Update scaffolded modules to avoid sanity errors

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -203,7 +203,7 @@ $ tree -lla /home/ansible-dev/collections/ansible_collections/testns/testname
 
 **Note:**
 
-The scaffolded collection includes a `hello_world` filter plugin, along with a
+The scaffolded collection includes a `sample_filter` filter plugin, along with a
 molecule scenario and an integration test target for it, that can be run using
 `pytest`. This serves as an example for you to refer when writing tests for your
 Ansible plugins and can be removed when it is no longer required.

--- a/src/ansible_creator/resources/collection_project/plugins/modules/sample_module.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/modules/sample_module.py.j2
@@ -3,6 +3,7 @@
 {%- set author = author |  default("Your Name (@username)") -%}
 {%- set description = description | default("A custom module plugin for Ansible.") -%}
 {%- set license = license | default("GPL-3.0-or-later") -%}
+#!/usr/bin/python
 # {{ module_name }}.py - {{ description }}
 # Author: {{ author }}
 # License: {{ license }}
@@ -10,17 +11,8 @@
 from __future__ import absolute_import, annotations, division, print_function
 
 
-__metaclass__ = type  # pylint: disable=C0103
-
-from typing import TYPE_CHECKING
-
-
-if TYPE_CHECKING:
-    from typing import Callable
-
-
 DOCUMENTATION = """
-    name: {{ module_name }}
+    module: {{ module_name }}
     author: {{ author }}
     version_added: "1.0.0"
     short_description: {{ description }}
@@ -41,6 +33,17 @@ EXAMPLES = """
 """
 
 
+__metaclass__ = type  # pylint: disable=C0103
+
+from typing import TYPE_CHECKING
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+
 def _sample_module(name: str) -> str:
     """Returns Hello message.
 
@@ -53,13 +56,20 @@ def _sample_module(name: str) -> str:
     return "Hello, " + name
 
 
-class SampleModule:
-    """module plugin."""
+def main():
+    """entry point for module execution"""
+    argument_spec = dict(
+        name=dict(type="str"),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
 
-    def modules(self) -> dict[str, Callable[[str], str]]:
-        """Map module plugin names to their functions.
+    _sample_module(module.params["name"])
 
-        Returns:
-            dict: The module plugin functions.
-        """
-        return {"{{ module_name }}": _sample_module}
+    result = {"changed": False}
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ansible_creator/resources/collection_project/plugins/modules/sample_module.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/modules/sample_module.py.j2
@@ -8,6 +8,7 @@
 # {{ module_name }}.py - {{ description }}
 # Author: {{ author }}
 # License: {{ license }}
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, annotations, division, print_function
 

--- a/src/ansible_creator/resources/collection_project/plugins/modules/sample_module.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/modules/sample_module.py.j2
@@ -4,6 +4,7 @@
 {%- set description = description | default("A custom module plugin for Ansible.") -%}
 {%- set license = license | default("GPL-3.0-or-later") -%}
 #!/usr/bin/python
+# pylint: disable=E0401
 # {{ module_name }}.py - {{ description }}
 # Author: {{ author }}
 # License: {{ license }}
@@ -37,7 +38,7 @@ __metaclass__ = type  # pylint: disable=C0103
 
 from typing import TYPE_CHECKING
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
 
 
 if TYPE_CHECKING:
@@ -56,7 +57,7 @@ def _sample_module(name: str) -> str:
     return "Hello, " + name
 
 
-def main():
+def main() -> None:
     """entry point for module execution"""
     argument_spec = dict(
         name=dict(type="str"),

--- a/src/ansible_creator/resources/collection_project/plugins/test/sample_test.py.j2
+++ b/src/ansible_creator/resources/collection_project/plugins/test/sample_test.py.j2
@@ -29,6 +29,7 @@ DOCUMENTATION = """
     options:
       name:
         type: bool
+        description: This is a sample option.
 """
 
 EXAMPLES = """

--- a/src/ansible_creator/resources/collection_project/tests/integration/targets/hello_world/tasks/main.yml.j2
+++ b/src/ansible_creator/resources/collection_project/tests/integration/targets/hello_world/tasks/main.yml.j2
@@ -1,7 +1,7 @@
 ---
 - name: Test the Hello World filter plugin
   ansible.builtin.set_fact:
-    msg: {% raw %}"{{ 'ansible-creator' | {% endraw %}{{ namespace }}.{{ collection_name }}.{% raw %}hello_world }}"{% endraw %}
+    msg: {% raw %}"{{ 'ansible-creator' | {% endraw %}{{ namespace }}.{{ collection_name }}.{% raw %}sample_filter }}"{% endraw %}
 
 - name: Assert that the filter worked
   ansible.builtin.assert:

--- a/tests/fixtures/collection/testorg/testcol/plugins/modules/sample_module.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/modules/sample_module.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# pylint: disable=E0401
 # sample_module.py - A custom module plugin for Ansible.
 # Author: Your Name (@username)
 # License: GPL-3.0-or-later
@@ -32,7 +33,7 @@ __metaclass__ = type  # pylint: disable=C0103
 
 from typing import TYPE_CHECKING
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
 
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ def _sample_module(name: str) -> str:
     return "Hello, " + name
 
 
-def main():
+def main() -> None:
     """entry point for module execution"""
     argument_spec = dict(
         name=dict(type="str"),

--- a/tests/fixtures/collection/testorg/testcol/plugins/modules/sample_module.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/modules/sample_module.py
@@ -3,6 +3,7 @@
 # sample_module.py - A custom module plugin for Ansible.
 # Author: Your Name (@username)
 # License: GPL-3.0-or-later
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, annotations, division, print_function
 

--- a/tests/fixtures/collection/testorg/testcol/plugins/modules/sample_module.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/modules/sample_module.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # sample_module.py - A custom module plugin for Ansible.
 # Author: Your Name (@username)
 # License: GPL-3.0-or-later
@@ -5,17 +6,8 @@
 from __future__ import absolute_import, annotations, division, print_function
 
 
-__metaclass__ = type  # pylint: disable=C0103
-
-from typing import TYPE_CHECKING
-
-
-if TYPE_CHECKING:
-    from typing import Callable
-
-
 DOCUMENTATION = """
-    name: sample_module
+    module: sample_module
     author: Your Name (@username)
     version_added: "1.0.0"
     short_description: A custom module plugin for Ansible.
@@ -36,6 +28,17 @@ EXAMPLES = """
 """
 
 
+__metaclass__ = type  # pylint: disable=C0103
+
+from typing import TYPE_CHECKING
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+
 def _sample_module(name: str) -> str:
     """Returns Hello message.
 
@@ -48,13 +51,20 @@ def _sample_module(name: str) -> str:
     return "Hello, " + name
 
 
-class SampleModule:
-    """module plugin."""
+def main():
+    """entry point for module execution"""
+    argument_spec = dict(
+        name=dict(type="str"),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
 
-    def modules(self) -> dict[str, Callable[[str], str]]:
-        """Map module plugin names to their functions.
+    _sample_module(module.params["name"])
 
-        Returns:
-            dict: The module plugin functions.
-        """
-        return {"sample_module": _sample_module}
+    result = {"changed": False}
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/collection/testorg/testcol/plugins/test/sample_test.py
+++ b/tests/fixtures/collection/testorg/testcol/plugins/test/sample_test.py
@@ -24,6 +24,7 @@ DOCUMENTATION = """
     options:
       name:
         type: bool
+        description: This is a sample option.
 """
 
 EXAMPLES = """

--- a/tests/fixtures/collection/testorg/testcol/tests/integration/targets/hello_world/tasks/main.yml
+++ b/tests/fixtures/collection/testorg/testcol/tests/integration/targets/hello_world/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Test the Hello World filter plugin
   ansible.builtin.set_fact:
-    msg: "{{ 'ansible-creator' | testorg.testcol.hello_world }}"
+    msg: "{{ 'ansible-creator' | testorg.testcol.sample_filter }}"
 
 - name: Assert that the filter worked
   ansible.builtin.assert:


### PR DESCRIPTION
See https://github.com/ansible/tox-ansible/actions/runs/14998128541/job/42137739053?pr=436

tox-ansible uses the output of ansible-creator to test sanity and integration runs. Unfortunately, as of 25.3.0, the generated content does not pass sanity or integration checks. This is an attempt to bring those scaffolded files into compliance.

The added license in sample_module is to allow `validate-module`'s `missing-gplv3-license` check to pass. _Arguably_, this test should be added to a global ignores, but as the license is added to other plugins automatically, I deemed it out of scope to fix properly.