### PR TITLE
Add play argspec example to patterns playbooks/meta/ directory

### DIFF
--- a/src/ansible_creator/resources/common/patterns/sample_pattern/playbooks/meta/site.yml
+++ b/src/ansible_creator/resources/common/patterns/sample_pattern/playbooks/meta/site.yml
@@ -1,0 +1,19 @@
+---
+short_description: Display weather forecast
+description: This playbook retrieves and displays a weather forecast from a specific airport location
+argument_specs:
+  weather_forecast:
+    short_description: Get weather forecast
+    description:
+      - Use an airport code to retrieve and display weather forecast data
+    author:
+      - developer (@developer)
+    options:
+      airport_code:
+        type: str
+        required: true
+    examples: |
+      - import_playbook: site.yml
+        vars:
+          airport_code: RDU
+    return: ~

--- a/src/ansible_creator/resources/common/patterns/sample_pattern/playbooks/site.yml
+++ b/src/ansible_creator/resources/common/patterns/sample_pattern/playbooks/site.yml
@@ -11,12 +11,9 @@
 
     - name: Ensure the airport code has been defined
       ansible.builtin.validate_argument_spec:
-        argument_spec: "{{ airport_code_argspec }}"
+        argument_spec: "{{ (lookup('ansible.builtin.file', filename) | from_yaml)['argument_specs']['weather_forecast']['options'] }}"
       vars:
-        airport_code_argspec:
-          airport_code:
-            type: str
-            required: true
+        filename: "meta/site.yml"
 
     - name: Clone the latitude longtude repo locally
       ansible.scm.git_retrieve:


### PR DESCRIPTION
Adds a full argspec for the example patterns playbook `site.yml`. 

This structure follows the patterns specification detailed [here](https://github.com/ansible/pattern-service/pull/10). 

Jira: [AAP-46624](https://issues.redhat.com/browse/AAP-46624)