### PR TITLE
Enable yaml syntax highlighting for jinja2 templated files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,9 @@
   "python.testing.pytestArgs": ["tests"],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
+  "files.associations": {
+    "*.j2": "yaml"
+  },
   "triggerTaskOnSave.tasks": {
     "pydoclint": ["*.py"]
   },


### PR DESCRIPTION
### SUMMARY

This PR adds a file association in settings.json to treat all `*.j2` files as YAML. This enables YAML syntax highlighting and language features for Jinja2 template files, making it easier to work with Ansible files and templates that use the .j2 extension.

Fixes: https://github.com/ansible/ansible-creator/issues/221