### PR TITLE
Enable templating for pattern name in pattern.json file

### DIFF
--- a/src/ansible_creator/resources/common/patterns/sample_pattern/meta/pattern.json.j2
+++ b/src/ansible_creator/resources/common/patterns/sample_pattern/meta/pattern.json.j2
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "name": "weather_forecasting",
+  "name": "{{ pattern_name }}",
   "title": "Weather Forecasting",
   "description": "This pattern is designed to help get the weather forecast for a given airport code. It creates a project, EE, and job templates in automation controller to get the weather forecast.",
   "short_description": "This pattern is designed to help get the weather forecast for a given airport code.",

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -455,8 +455,6 @@ class Add:
         return TemplateData(
             resource_type=self._resource_type,
             pattern_name=self._pattern_name,
-            namespace=self._namespace,
-            collection_name=self._collection_name,
             creator_version=self._creator_version,
         )
 


### PR DESCRIPTION
### Summary

- This PR dynamically set the pattern name based on the CLI input.
- [This](https://github.com/ansible/ansible-creator/blob/main/src/ansible_creator/resources/common/patterns/sample_pattern/meta/pattern.json#L3) name field needs to be set as actual pattern name received from CLI and the one used in pattern directory name.
