### PR TITLE
fix: improve prompt visibility in light terminal themes

### DIFF
--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -417,5 +417,5 @@ def ask_yes_no(question: str) -> bool:
     """
     answer = ""
     while answer not in ["y", "n"]:
-        answer = input(f"{Color.BRIGHT_WHITE}{question} (y/n){Color.END}: ").lower()
+        answer = input(f"{Color.MAGENTA}{question} (y/n){Color.END}: ").lower()
     return answer == "y"


### PR DESCRIPTION
  Change `Color.BRIGHT_WHITE` to `Color.MAGENTA` for y/n prompts to fix
  visibility issue in light terminal themes.

  Fixes #438

 Signed-off-by: Shreyansh Sancheti <43677304+shreyanshjain7174@users.noreply.github.com>