### PR TITLE
fix: ensure scaffolded role variables have expected prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -350,7 +350,8 @@ enable = ["useless-suppression"]
 fail-on = ["useless-suppression"]
 
 [tool.pytest.ini_options]
-addopts = "-ra --showlocals --durations=10"
+# -v is needed to see diff reports
+addopts = "-v -ra --showlocals --durations=10"
 cache_dir = "./.cache/.pytest"
 junit_family = "xunit2"  # see https://docs.codecov.com/docs/test-analytics
 norecursedirs = "tests/fixtures"

--- a/src/ansible_creator/resources/common/role/roles/run/defaults/main.yml.j2
+++ b/src/ansible_creator/resources/common/role/roles/run/defaults/main.yml.j2
@@ -1,2 +1,6 @@
 ---
 # defaults file for {{ namespace }}.{{ collection_name }}.{{ role_name }}
+
+# Variable that will be displayed in debug output
+# This demonstrates proper role variable naming with the 'run_' prefix
+{{ role_name }}_my_variable: "default_value"

--- a/src/ansible_creator/resources/common/role/roles/run/meta/argument_specs.yml.j2
+++ b/src/ansible_creator/resources/common/role/roles/run/meta/argument_specs.yml.j2
@@ -5,7 +5,7 @@ argument_specs:
   main:
     short_description: Role description.
     options:
-      my_variable:
+      {{ role_name }}_my_variable:
         type: str
         description: A simple string argument for demonstration.
         default: "default_value"

--- a/src/ansible_creator/resources/common/role/roles/run/tasks/main.yml.j2
+++ b/src/ansible_creator/resources/common/role/roles/run/tasks/main.yml.j2
@@ -1,7 +1,6 @@
 ---
 # tasks file for {{ namespace }}.{{ collection_name }}.{{ role_name }}
 
-# task example for debugging a value
-- name: Debug the value of my_variable
+- name: Display the value of {{ role_name }}_my_variable
   ansible.builtin.debug:
-    msg: "The value of my_variable is {% raw %}{{ my_variable }}{% endraw %}"
+    msg: "The value of {{ role_name }}_my_variable is {% raw %}{{ {% endraw %}{{ role_name }}_my_variable{% raw %} }}{% endraw %}"

--- a/tests/fixtures/collection/testorg/testcol/roles/run/defaults/main.yml
+++ b/tests/fixtures/collection/testorg/testcol/roles/run/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 # defaults file for testorg.testcol.run
+
+# Variable that will be displayed in debug output
+# This demonstrates proper role variable naming with the 'run_' prefix
+run_my_variable: "default_value"

--- a/tests/fixtures/collection/testorg/testcol/roles/run/meta/argument_specs.yml
+++ b/tests/fixtures/collection/testorg/testcol/roles/run/meta/argument_specs.yml
@@ -5,7 +5,7 @@ argument_specs:
   main:
     short_description: Role description.
     options:
-      my_variable:
+      run_my_variable:
         type: str
         description: A simple string argument for demonstration.
         default: "default_value"

--- a/tests/fixtures/collection/testorg/testcol/roles/run/tasks/main.yml
+++ b/tests/fixtures/collection/testorg/testcol/roles/run/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for testorg.testcol.run
 
-# task example for debugging a value
-- name: Debug the value of my_variable
+- name: Display the value of run_my_variable
   ansible.builtin.debug:
-    msg: "The value of my_variable is {{ my_variable }}"
+    msg: "The value of run_my_variable is {{ run_my_variable }}"

--- a/tests/units/test_output.py
+++ b/tests/units/test_output.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+import os
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -22,13 +23,22 @@ if TYPE_CHECKING:
 def test_console_width(width: int, expected: int, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the console width function."""
 
-    def mock_get_terminal_size() -> SimpleNamespace:
-        return SimpleNamespace(columns=width, lines=24)
+    def mock_get_terminal_size(
+        fallback: tuple[int, int] = (80, 24),  # noqa: ARG001
+    ) -> tuple[int, int]:
+        """Mock the get_terminal_size function.
+
+        Args:
+            fallback: Default terminal size.
+
+        Returns:
+            Mocked terminal size.
+        """
+        return os.terminal_size((width, 24))
 
     monkeypatch.setattr("shutil.get_terminal_size", mock_get_terminal_size)
 
     monkeypatch.delenv("COLUMNS", raising=False)
-
     assert console_width() == expected
 
 


### PR DESCRIPTION
Resolves issue discovered while working on #481

Partial: #481
