### PR TITLE
feat: Add option to disable validate_certs

### DIFF
--- a/docs/ee_scaffolding.md
+++ b/docs/ee_scaffolding.md
@@ -108,7 +108,8 @@ one `[galaxy_server.<id>]` section:
     {
       "id": "private_hub",
       "url": "https://pah.corp.example.com/api/galaxy/content/published/",
-      "token_required": true
+      "token_required": true,
+      "validate_certs": false
     },
     {
       "id": "galaxy",
@@ -124,6 +125,7 @@ one `[galaxy_server.<id>]` section:
 | `url` | yes | Galaxy server content URL |
 | `auth_url` | no | SSO/OAuth token endpoint (e.g. Red Hat SSO) |
 | `token_required` | no | When `true`, the workflow wires up the corresponding repository secret |
+| `validate_certs` | no | hen `false`, writes `validate_certs = false` for that server in `ansible.cfg` (private CA / lab only; prefer trusting the CA in the EE image) |
 
 When `galaxy_servers` is provided, ansible-creator generates an `ansible.cfg`
 with the server list and a comment for each server that requires a token:
@@ -139,6 +141,7 @@ auth_url = https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-co
 
 [galaxy_server.private_hub]
 url = https://pah.corp.example.com/api/galaxy/content/published/
+validate_certs = false
 # Token: set ANSIBLE_GALAXY_SERVER_PRIVATE_HUB_TOKEN as a repository secret
 
 [galaxy_server.galaxy]

--- a/docs/ee_scaffolding.md
+++ b/docs/ee_scaffolding.md
@@ -125,7 +125,7 @@ one `[galaxy_server.<id>]` section:
 | `url` | yes | Galaxy server content URL |
 | `auth_url` | no | SSO/OAuth token endpoint (e.g. Red Hat SSO) |
 | `token_required` | no | When `true`, the workflow wires up the corresponding repository secret |
-| `validate_certs` | no | hen `false`, writes `validate_certs = false` for that server in `ansible.cfg` (private CA / lab only; prefer trusting the CA in the EE image) |
+| `validate_certs` | no | When `false`, writes `validate_certs = false` for that server in `ansible.cfg` (private CA / lab only; prefer trusting the CA in the EE image) |
 
 When `galaxy_servers` is provided, ansible-creator generates an `ansible.cfg`
 with the server list and a comment for each server that requires a token:

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -528,6 +528,8 @@ class Init:
             lines.append(f"url = {server.url}")
             if server.auth_url:
                 lines.append(f"auth_url = {server.auth_url}")
+            if not server.validate_certs:
+                lines.append("validate_certs = false")
             if server.token_required:
                 token_var = f"ANSIBLE_GALAXY_SERVER_{server.id.upper()}_TOKEN"
                 lines.append(f"# Token: set {token_var} as a repository secret")

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -205,12 +205,17 @@ class GalaxyServer:
         url: Galaxy server content URL.
         auth_url: SSO/OAuth token endpoint (for Red Hat SSO-backed servers).
         token_required: Whether this server needs a token at build time.
+        validate_certs: Whether to verify TLS certificates for this Galaxy/AH server.
+            When ``False``, ``validate_certs = false`` is written to ``ansible.cfg``
+            for that ``[galaxy_server.<id>]`` section (e.g. private hubs with a
+            CA not present in the EE image).
     """
 
     id: str
     url: str
     auth_url: str = ""
     token_required: bool = False
+    validate_certs: bool = True
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> GalaxyServer:
@@ -245,6 +250,7 @@ class GalaxyServer:
             url=data["url"],
             auth_url=data.get("auth_url", ""),
             token_required=data.get("token_required", False),
+            validate_certs=data.get("validate_certs", True),
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -259,6 +265,7 @@ class GalaxyServer:
             "id": self.id,
             "url": self.url,
             "token_required": self.token_required,
+            "validate_certs": self.validate_certs,
             "token_env_var": f"ANSIBLE_GALAXY_SERVER_{self.id.upper()}_TOKEN",
         }
         if self.auth_url:
@@ -297,6 +304,15 @@ class GalaxyServer:
                     "type": "boolean",
                     "default": False,
                     "description": "Whether this server needs a token at build time",
+                },
+                "validate_certs": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": (
+                        "Whether to verify TLS for this Galaxy/AH server. "
+                        "Set to false for Automation hubs with private CAs when the EE image "
+                        "does not trust that CA."
+                    ),
                 },
             },
         }

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -126,6 +126,29 @@ def has_differences(dcmp: dircmp[str], errors: list[str]) -> list[str]:
     return errors
 
 
+def _galaxy_server_ini_section(ansible_cfg: str, server_id: str) -> str:
+    """Return the body of a ``[galaxy_server.<server_id>]`` INI section.
+
+    The slice starts immediately after the header line and ends before the next
+    ``[`` at the beginning of a line (next section) or EOF.
+
+    Args:
+        ansible_cfg: Full ``ansible.cfg`` file contents.
+        server_id: Galaxy server id matching the section name.
+
+    Returns:
+        Text after ``[galaxy_server.<server_id>]`` through the line before the
+        next section header.
+    """
+    header = f"[galaxy_server.{server_id}]"
+    start = ansible_cfg.index(header) + len(header)
+    tail = ansible_cfg[start:]
+    next_idx = tail.find("\n[")
+    if next_idx == -1:
+        return tail
+    return tail[:next_idx]
+
+
 def test_run_success_ee_project(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
@@ -760,6 +783,7 @@ def test_ee_project_with_galaxy_servers(
                 "id": "private_hub",
                 "url": "https://pah.corp.example.com/api/galaxy/content/published/",
                 "token_required": True,
+                "validate_certs": False,
             },
             {
                 "id": "galaxy",
@@ -786,6 +810,12 @@ def test_ee_project_with_galaxy_servers(
     assert "auth_url = https://sso.redhat.com/" in cfg
     assert "[galaxy_server.private_hub]" in cfg
     assert "pah.corp.example.com" in cfg
+    private_hub_section = _galaxy_server_ini_section(cfg, "private_hub")
+    assert "validate_certs = false" in private_hub_section
+    assert private_hub_section.count("validate_certs = false") == 1
+    assert "validate_certs = false" not in _galaxy_server_ini_section(cfg, "automation_hub")
+    assert "validate_certs = false" not in _galaxy_server_ini_section(cfg, "galaxy")
+    assert cfg.count("validate_certs = false") == 1
     assert "[galaxy_server.galaxy]" in cfg
     assert "galaxy.ansible.com" in cfg
     # Token comments for servers with token_required
@@ -1329,6 +1359,7 @@ def test_ee_config_from_dict_galaxy_servers() -> None:
                 "id": "private_hub",
                 "url": "https://pah.corp.example.com/api/galaxy/content/published/",
                 "token_required": True,
+                "validate_certs": False,
             },
             {
                 "id": "galaxy",
@@ -1343,10 +1374,13 @@ def test_ee_config_from_dict_galaxy_servers() -> None:
     assert "console.redhat.com" in cfg.galaxy_servers[0].url
     assert "sso.redhat.com" in cfg.galaxy_servers[0].auth_url
     assert cfg.galaxy_servers[0].token_required is True
+    assert cfg.galaxy_servers[0].validate_certs is True
     assert cfg.galaxy_servers[1].id == "private_hub"
     assert cfg.galaxy_servers[1].token_required is True
+    assert cfg.galaxy_servers[1].validate_certs is False
     assert cfg.galaxy_servers[2].id == "galaxy"
     assert cfg.galaxy_servers[2].token_required is False
+    assert cfg.galaxy_servers[2].validate_certs is True
 
 
 def test_ee_config_from_dict_registry_and_image_name() -> None:
@@ -1579,6 +1613,20 @@ def test_galaxy_server_from_dict_full() -> None:
     assert "console.redhat.com" in server.url
     assert "sso.redhat.com" in server.auth_url
     assert server.token_required is True
+    assert server.validate_certs is True
+
+
+def test_galaxy_server_from_dict_validate_certs_false() -> None:
+    """Test GalaxyServer.from_dict with validate_certs false."""
+    server = GalaxyServer.from_dict(
+        {
+            "id": "internal_hub",
+            "url": "https://10.0.0.1/api/galaxy/content/published/",
+            "validate_certs": False,
+        },
+    )
+    assert server.id == "internal_hub"
+    assert server.validate_certs is False
 
 
 def test_galaxy_server_from_dict_minimal() -> None:
@@ -1589,6 +1637,7 @@ def test_galaxy_server_from_dict_minimal() -> None:
     assert server.url == "https://galaxy.ansible.com/"
     assert server.auth_url == ""
     assert server.token_required is False
+    assert server.validate_certs is True
 
 
 def test_galaxy_server_from_dict_missing_id() -> None:
@@ -1619,6 +1668,7 @@ def test_galaxy_server_as_dict() -> None:
         url="https://example.com/",
         auth_url="https://sso.example.com/token",
         token_required=True,
+        validate_certs=True,
     )
     result = server.as_dict()
 
@@ -1626,6 +1676,7 @@ def test_galaxy_server_as_dict() -> None:
     assert result["url"] == "https://example.com/"
     assert result["auth_url"] == "https://sso.example.com/token"
     assert result["token_required"] is True
+    assert result["validate_certs"] is True
     expected_var = "ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN"
     assert result["token_env_var"] == expected_var
 
@@ -1636,6 +1687,7 @@ def test_galaxy_server_as_dict_no_auth_url() -> None:
     result = server.as_dict()
 
     assert "auth_url" not in result
+    assert result["validate_certs"] is True
     expected_var = "ANSIBLE_GALAXY_SERVER_GALAXY_TOKEN"
     assert result["token_env_var"] == expected_var
 
@@ -1652,6 +1704,7 @@ def test_galaxy_server_to_schema() -> None:
     assert "url" in props
     assert "auth_url" in props
     assert "token_required" in props
+    assert "validate_certs" in props
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Adds an optional validate_certs field on each galaxy_servers entry in EE configuration (--ee-config / --ee-config-file). When set to false, the generated ansible.cfg includes validate_certs = false for that [galaxy_server.<id>] section so ansible-galaxy can talk to hubs that use certificates the EE image does not trust (for example, internal Automation Hub with a private CA).

### Example

```
{
  "galaxy_servers": [
    {
      "id": "private_hub",
      "url": "https://pah.example.com/api/galaxy/content/published/",
      "token_required": true,
      "validate_certs": false
    }
  ]
}
```

### Steps to check
```
rm -rf /tmp/ee-validate-certs-test
uv run ansible-creator init execution_env /tmp/ee-validate-certs-test \
  --ee-config '{
    "base_image": "registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:latest",
    "galaxy_servers": [
      {
        "id": "private_hub",
        "url": "https://pah.example.com/api/galaxy/content/published/",
        "token_required": true,
        "validate_certs": false
      },
      {
        "id": "galaxy",
        "url": "https://galaxy.ansible.com/"
      }
    ],
    "collections": [{"name": "ansible.posix"}]
  }'
  ```
  
  ### Tests
  
```
 uv run pytest tests/units/test_init_ee.py::test_ee_project_with_galaxy_servers \
  tests/units/test_init_ee.py::test_galaxy_server_from_dict_validate_certs_false -q
======================================================== test session starts =========================================================
platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
cachedir: .cache/.pytest
rootdir: /home/kbperbyte/Work/contributions/ansible-creator
configfile: pyproject.toml
plugins: instafail-0.5.0, xdist-3.8.0, plus-0.8.1
collected 2 items                                                                                                                    

tests/units/test_init_ee.py ..                                                                                                 [100%]

======================================================== slowest 10 durations ========================================================
0.01s call     tests/units/test_init_ee.py::test_ee_project_with_galaxy_servers

(5 durations < 0.005s hidden.  Use -vv to show these durations.)
```