### PR TITLE
chore(ci): use explicit _extends path for Release Drafter v7

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,3 @@
 ---
-# see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+# https://github.com/ansible/team-devtools — Release Drafter v7 needs repo:path for _extends
+_extends: ansible/team-devtools:/.github/release-drafter.yml


### PR DESCRIPTION
## Summary
Release Drafter was upgraded to v7 in [ansible/team-devtools#443](https://github.com/ansible/team-devtools/pull/443). v7 no longer accepts bare `_extends: owner/repo` and fails with:
`Unsupported file extension: .ansible/team-devtools`