### PR TITLE
feat: Add build_arg_defaults support for execution environment projects

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -28,6 +28,7 @@ ignoreWords:
   - adoc
   - argparser
   - dellos
+  - dictsort
   - endfor
   - envsubst
   - endif

--- a/src/ansible_creator/_arg_parser_custom.py
+++ b/src/ansible_creator/_arg_parser_custom.py
@@ -1,0 +1,125 @@
+"""Custom argparse formatter and parser used by ``arg_parser``."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from argparse import HelpFormatter
+from operator import attrgetter
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+
+class CustomHelpFormatter(HelpFormatter):  # pragma: no cover py>=3.14
+    """A custom help formatter."""
+
+    def __init__(self, prog: str) -> None:
+        """Initialize the help formatter.
+
+        Args:
+            prog: The program name
+        """
+        long_string = "--abc  --really_really_really_log"
+        # 3 here accounts for the spaces in the ljust(6) below
+        HelpFormatter.__init__(
+            self,
+            prog=prog,
+            indent_increment=1,
+            max_help_position=len(long_string) + 3,
+        )
+
+    def _format_action_invocation(
+        self,
+        action: argparse.Action,
+    ) -> str:
+        """Format the action invocation.
+
+        Args:
+            action: The action to format
+
+        Raises:
+            ValueError: If more than 2 options are given
+
+        Returns:
+            The formatted action invocation
+        """
+        if not action.option_strings:  # pragma: no branch
+            default = self._get_default_metavar_for_positional(action)
+            (metavar,) = self._metavar_formatter(action, default)(1)
+            return metavar
+
+        if len(action.option_strings) == 1:
+            return action.option_strings[0]
+
+        max_variations = 2
+        if len(action.option_strings) == max_variations:
+            # Account for a --1234 --long-option-name
+            return f"{action.option_strings[0].ljust(6)} {action.option_strings[1]}"
+        msg = "Too many option strings"
+        raise ValueError(msg)
+
+    def add_arguments(self, actions: Iterable[argparse.Action]) -> None:
+        """Add arguments sorted by option strings.
+
+        Args:
+            actions: The actions to add
+        """
+        actions = sorted(actions, key=attrgetter("option_strings"))
+        super().add_arguments(actions)
+
+
+class CustomArgumentParser(argparse.ArgumentParser):
+    """A custom argument parser."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        """Initialize the argument parser.
+
+        Args:
+            *args: The arguments
+            **kwargs: The keyword arguments
+        """
+        super().__init__(*args, **kwargs)
+        if sys.version_info < (3, 14):  # pragma: no cover py>=3.14
+            self.formatter_class = CustomHelpFormatter
+
+    def add_argument(  # type: ignore[override]
+        self,
+        *args: Any,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        """Add an argument.
+
+        Args:
+            *args: The arguments
+            **kwargs: The keyword arguments
+        """
+        if sys.version_info < (3, 14):  # pragma: no cover py>=3.14
+            if "choices" in kwargs:  # pragma: no cover py>=3.14
+                kwargs["help"] += f" (choices: {', '.join(kwargs['choices'])})"
+            if "default" in kwargs and kwargs["default"] != "==SUPPRESS==":
+                kwargs["help"] += f" (default: {kwargs['default']})"
+        super().add_argument(*args, **kwargs)
+
+    def add_argument_group(
+        self,
+        *args: Any,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401
+    ) -> argparse._ArgumentGroup:
+        """Add an argument group.
+
+        Args:
+            *args: The arguments
+            **kwargs: The keyword arguments
+
+        Returns:
+            The argument group
+        """
+        group = super().add_argument_group(*args, **kwargs)
+        if group.title:  # pragma: no cover
+            group.title = group.title.capitalize()
+        return group

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -7,17 +7,12 @@ import os
 import re
 import sys
 
-from argparse import HelpFormatter
-from operator import attrgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
 from ansible_creator.output import Level, Msg
 
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-    from typing import Any
+from ._arg_parser_custom import CustomArgumentParser
 
 
 try:
@@ -38,64 +33,6 @@ MAX_COLLECTION_NAME_LEN = 64
 
 if TYPE_CHECKING:
     SubParser: TypeAlias = argparse._SubParsersAction  # noqa: SLF001
-
-
-class CustomHelpFormatter(HelpFormatter):  # pragma: no cover py>=3.14
-    """A custom help formatter."""
-
-    def __init__(self, prog: str) -> None:
-        """Initialize the help formatter.
-
-        Args:
-            prog: The program name
-        """
-        long_string = "--abc  --really_really_really_log"
-        # 3 here accounts for the spaces in the ljust(6) below
-        HelpFormatter.__init__(
-            self,
-            prog=prog,
-            indent_increment=1,
-            max_help_position=len(long_string) + 3,
-        )
-
-    def _format_action_invocation(
-        self,
-        action: argparse.Action,
-    ) -> str:
-        """Format the action invocation.
-
-        Args:
-            action: The action to format
-
-        Raises:
-            ValueError: If more than 2 options are given
-
-        Returns:
-            The formatted action invocation
-        """
-        if not action.option_strings:  # pragma: no branch
-            default = self._get_default_metavar_for_positional(action)
-            (metavar,) = self._metavar_formatter(action, default)(1)
-            return metavar
-
-        if len(action.option_strings) == 1:
-            return action.option_strings[0]
-
-        max_variations = 2
-        if len(action.option_strings) == max_variations:
-            # Account for a --1234 --long-option-name
-            return f"{action.option_strings[0].ljust(6)} {action.option_strings[1]}"
-        msg = "Too many option strings"
-        raise ValueError(msg)
-
-    def add_arguments(self, actions: Iterable[argparse.Action]) -> None:
-        """Add arguments sorted by option strings.
-
-        Args:
-            actions: The actions to add
-        """
-        actions = sorted(actions, key=attrgetter("option_strings"))
-        super().add_arguments(actions)
 
 
 class Parser:
@@ -953,53 +890,4 @@ class Parser:
         return True
 
 
-class CustomArgumentParser(argparse.ArgumentParser):
-    """A custom argument parser."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
-        """Initialize the argument parser.
-
-        Args:
-            *args: The arguments
-            **kwargs: The keyword arguments
-        """
-        super().__init__(*args, **kwargs)
-        if sys.version_info < (3, 14):  # pragma: no cover py>=3.14
-            self.formatter_class = CustomHelpFormatter
-
-    def add_argument(  # type: ignore[override]
-        self,
-        *args: Any,  # noqa: ANN401
-        **kwargs: Any,  # noqa: ANN401
-    ) -> None:
-        """Add an argument.
-
-        Args:
-            *args: The arguments
-            **kwargs: The keyword arguments
-        """
-        if sys.version_info < (3, 14):  # pragma: no cover py>=3.14
-            if "choices" in kwargs:  # pragma: no cover py>=3.14
-                kwargs["help"] += f" (choices: {', '.join(kwargs['choices'])})"
-            if "default" in kwargs and kwargs["default"] != "==SUPPRESS==":
-                kwargs["help"] += f" (default: {kwargs['default']})"
-        super().add_argument(*args, **kwargs)
-
-    def add_argument_group(
-        self,
-        *args: Any,  # noqa: ANN401
-        **kwargs: Any,  # noqa: ANN401
-    ) -> argparse._ArgumentGroup:
-        """Add an argument group.
-
-        Args:
-            *args: The arguments
-            **kwargs: The keyword arguments
-
-        Returns:
-            The argument group
-        """
-        group = super().add_argument_group(*args, **kwargs)
-        if group.title:  # pragma: no cover
-            group.title = group.title.capitalize()
-        return group
+__all__ = ["CustomArgumentParser", "Parser"]

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -825,6 +825,16 @@ class Parser:
         )
 
         parser.add_argument(
+            "--ee-build-arg-default",
+            dest="ee_build_arg_defaults",
+            action="append",
+            default=[],
+            metavar="KEY=VALUE",
+            help="Default build ARG for the EE image (repeatable). "
+            "Example: --ee-build-arg-default ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre",
+        )
+
+        parser.add_argument(
             "--registry-tls-verify",
             dest="registry_tls_verify",
             action=argparse.BooleanOptionalAction,

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -47,6 +47,7 @@ class Config:
         ee_system_packages: List of system packages for execution environment.
         ee_name: Name/tag for the execution environment image.
         ee_file_name: Name of the EE definition file.
+        ee_build_arg_defaults: EE build ARG defaults as KEY=VALUE strings (from CLI).
         registry_tls_verify: Whether to verify TLS for container registry operations
             (login, pull, push, and image builds). None means the user did not
             explicitly set this flag, so the EE config file value is preserved.
@@ -79,6 +80,7 @@ class Config:
     ee_system_packages: Sequence[str] = field(default_factory=list)
     ee_name: str = "ansible_sample_ee"
     ee_file_name: str = "execution-environment.yml"
+    ee_build_arg_defaults: Sequence[str] = field(default_factory=list)
     registry_tls_verify: bool | None = None
 
     def __post_init__(self) -> None:

--- a/src/ansible_creator/resources/execution_env_project/execution-environment.yml.j2
+++ b/src/ansible_creator/resources/execution_env_project/execution-environment.yml.j2
@@ -4,6 +4,13 @@ version: 3
 images:
   base_image:
     name: {{ ee_base_image }}
+{%- if ee_build_arg_defaults %}
+
+build_arg_defaults:
+{%- for key, val in ee_build_arg_defaults | dictsort %}
+  {{ key }}: {{ val | json }}
+{%- endfor %}
+{%- endif %}
 
 dependencies:
 {%- if not is_official_ee %}

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -26,6 +26,8 @@ from ansible_creator.utils import Copier, Walker, ask_yes_no
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
     from ansible_creator.config import Config
     from ansible_creator.output import Output
 
@@ -183,25 +185,7 @@ class Init:
         """
         ee_cfg = self._resolve_ee_config(config)
 
-        # CLI flags override values from config JSON/file.
-        overrides: dict[str, Any] = {}
-        if config.base_image != "quay.io/fedora/fedora:41":
-            overrides["base_image"] = config.base_image
-        if config.ee_name != "ansible_sample_ee":
-            overrides["ee_name"] = config.ee_name
-        if config.ee_collections:
-            overrides["collections"] = tuple(
-                self._parse_single_collection(c) for c in config.ee_collections
-            )
-        if config.ee_python_deps:
-            overrides["python_deps"] = tuple(config.ee_python_deps)
-        if config.ee_system_packages:
-            overrides["system_packages"] = tuple(config.ee_system_packages)
-        if config.ee_file_name != "execution-environment.yml":
-            overrides["ee_file_name"] = config.ee_file_name
-        if config.registry_tls_verify is not None:
-            overrides["registry_tls_verify"] = config.registry_tls_verify
-
+        overrides = Init._ee_cli_flag_overrides(config, ee_cfg, self._parse_single_collection)
         if overrides:
             ee_cfg = dataclasses.replace(ee_cfg, **overrides)
 
@@ -213,6 +197,73 @@ class Init:
             ee_cfg = dataclasses.replace(ee_cfg, options=updated_opts)
 
         return ee_cfg
+
+    @staticmethod
+    def _ee_cli_flag_overrides(
+        config: Config,
+        ee_cfg: EEConfig,
+        parse_collection: Callable[[str], EECollection],
+    ) -> dict[str, Any]:
+        """Build field overrides from CLI flags (relative to JSON/file EE config).
+
+        Args:
+            config: Application configuration.
+            ee_cfg: EE configuration from ``--ee-config`` / file before CLI overlay.
+            parse_collection: ``Init._parse_single_collection`` bound method.
+
+        Returns:
+            Mapping suitable for ``dataclasses.replace(ee_cfg, **overrides)``.
+        """
+        overrides: dict[str, Any] = {}
+        if config.base_image != "quay.io/fedora/fedora:41":
+            overrides["base_image"] = config.base_image
+        if config.ee_name != "ansible_sample_ee":
+            overrides["ee_name"] = config.ee_name
+        if config.ee_collections:
+            overrides["collections"] = tuple(parse_collection(c) for c in config.ee_collections)
+        if config.ee_python_deps:
+            overrides["python_deps"] = tuple(config.ee_python_deps)
+        if config.ee_system_packages:
+            overrides["system_packages"] = tuple(config.ee_system_packages)
+        if config.ee_file_name != "execution-environment.yml":
+            overrides["ee_file_name"] = config.ee_file_name
+        if config.registry_tls_verify is not None:
+            overrides["registry_tls_verify"] = config.registry_tls_verify
+        if config.ee_build_arg_defaults:
+            merged_args = dict(ee_cfg.build_arg_defaults)
+            merged_args.update(Init._parse_cli_build_arg_defaults(config.ee_build_arg_defaults))
+            overrides["build_arg_defaults"] = merged_args
+        return overrides
+
+    @staticmethod
+    def _parse_cli_build_arg_defaults(items: Sequence[str]) -> dict[str, str]:
+        """Parse ``--ee-build-arg-default`` values into a name/value mapping.
+
+        Args:
+            items: Raw ``KEY=VALUE`` strings from the CLI.
+
+        Returns:
+            Mapping of build ARG name to default value.
+
+        Raises:
+            CreatorError: If any entry is not of the form ``KEY=VALUE``.
+        """
+        result: dict[str, str] = {}
+        for raw in items:
+            if "=" not in raw:
+                msg = (
+                    f"Invalid --ee-build-arg-default {raw!r}: expected KEY=VALUE "
+                    "(e.g. ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre)"
+                )
+                raise CreatorError(msg)
+            key, _, value = raw.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if not key:
+                msg = f"Invalid --ee-build-arg-default {raw!r}: empty key"
+                raise CreatorError(msg)
+            result[key] = value
+        return result
 
     @staticmethod
     def _resolve_ee_config(config: Config) -> EEConfig:
@@ -424,6 +475,8 @@ class Init:
             ee_scm_servers=[s.as_dict() for s in ec.scm_servers],
             ee_scm_token_vars=[s.token_env_var for s in ec.scm_servers],
             ee_file_name=ec.ee_file_name,
+            scm_provider=self._scm_provider,
+            ee_build_arg_defaults=dict(ec.build_arg_defaults),
         )
 
         if self._project == "execution_env":

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -475,7 +475,6 @@ class Init:
             ee_scm_servers=[s.as_dict() for s in ec.scm_servers],
             ee_scm_token_vars=[s.token_env_var for s in ec.scm_servers],
             ee_file_name=ec.ee_file_name,
-            scm_provider=self._scm_provider,
             ee_build_arg_defaults=dict(ec.build_arg_defaults),
         )
 

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -430,6 +430,8 @@ class EEConfig:
         additional_build_files: Extra files for the build context.
         additional_build_steps: Custom build steps keyed by phase.
         options: Build options (e.g. package_manager_path).
+        build_arg_defaults: Default ARG values for the container build (e.g.
+            ANSIBLE_GALAXY_CLI_COLLECTION_OPTS).
         ansible_cfg: Content for an ansible.cfg file.
         galaxy_servers: Galaxy server entries for ansible.cfg generation and
             workflow token plumbing.
@@ -451,6 +453,7 @@ class EEConfig:
             "additional_build_files",
             "additional_build_steps",
             "options",
+            "build_arg_defaults",
             "ansible_cfg",
             "galaxy_servers",
             "scm_servers",
@@ -469,6 +472,7 @@ class EEConfig:
     additional_build_files: tuple[dict[str, str], ...] = ()
     additional_build_steps: dict[str, list[str]] = field(default_factory=dict)
     options: dict[str, Any] = field(default_factory=dict)
+    build_arg_defaults: dict[str, str] = field(default_factory=dict)
     ansible_cfg: str = ""
     galaxy_servers: tuple[GalaxyServer, ...] = ()
     scm_servers: tuple[ScmServer, ...] = ()
@@ -500,6 +504,16 @@ class EEConfig:
             EECollection.from_dict(c if isinstance(c, dict) else {"name": c})
             for c in raw_collections
         )
+        raw_build_args = data.get("build_arg_defaults", {})
+        if not isinstance(raw_build_args, dict):
+            msg = "build_arg_defaults must be a mapping of string keys to string values"
+            raise CreatorError(msg)
+        build_arg_defaults: dict[str, str] = {}
+        for bk, bv in raw_build_args.items():
+            if not isinstance(bk, str) or not isinstance(bv, str):
+                msg = "build_arg_defaults must be a mapping of string keys to string values"
+                raise CreatorError(msg)
+            build_arg_defaults[bk] = bv
         registry = data.get("registry", "ghcr.io")
         if "://" in registry:
             msg = f"Invalid registry '{registry}'. Provide a hostname (e.g. 'ghcr.io'), not a URL."
@@ -521,6 +535,7 @@ class EEConfig:
             additional_build_files=tuple(data.get("additional_build_files", [])),
             additional_build_steps=data.get("additional_build_steps", {}),
             options=dict(data.get("options", {})),
+            build_arg_defaults=build_arg_defaults,
             ansible_cfg=data.get("ansible_cfg", ""),
             galaxy_servers=galaxy_servers,
             scm_servers=scm_servers,
@@ -626,6 +641,14 @@ class EEConfig:
                     "type": "object",
                     "description": "Build options (e.g. package_manager_path)",
                 },
+                "build_arg_defaults": {
+                    "type": "object",
+                    "description": (
+                        "Default ARG values for the EE image build "
+                        "(e.g. ANSIBLE_GALAXY_CLI_COLLECTION_OPTS)"
+                    ),
+                    "additionalProperties": {"type": "string"},
+                },
                 "ansible_cfg": {
                     "type": "string",
                     "description": "Content for ansible.cfg file",
@@ -725,6 +748,7 @@ class TemplateData:
         ee_additional_build_steps: Dict with prepend_base, append_base, prepend_final,
             append_final steps.
         ee_options: Dict of EE build options (e.g., package_manager_path).
+        ee_build_arg_defaults: Default ARG values for the EE container build.
         ee_ansible_cfg: Content for ansible.cfg file (for Automation Hub auth).
         is_official_ee: Whether the base image is an official Red Hat EE image.
         ee_python_path: Python interpreter path for the EE (varies by AAP version).
@@ -766,6 +790,7 @@ class TemplateData:
     ee_additional_build_files: Sequence[dict[str, str]] = field(default_factory=list)
     ee_additional_build_steps: dict[str, list[str]] = field(default_factory=dict)
     ee_options: dict[str, Any] = field(default_factory=dict)
+    ee_build_arg_defaults: dict[str, str] = field(default_factory=dict)
     ee_ansible_cfg: str = ""
     is_official_ee: bool = False
     ee_python_path: str = DEFAULT_PYTHON_PATH

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -44,6 +44,7 @@ class ConfigDict(TypedDict, total=False):
         ee_system_packages: List of system packages for execution environment.
         ee_name: Name/tag for the execution environment image.
         ee_file_name: Name of the EE definition file.
+        ee_build_arg_defaults: EE build ARG defaults as KEY=VALUE strings (CLI).
         registry_tls_verify: Whether to verify TLS for container registries.
     """
 
@@ -64,6 +65,7 @@ class ConfigDict(TypedDict, total=False):
     ee_system_packages: list[str]
     ee_name: str
     ee_file_name: str
+    ee_build_arg_defaults: list[str]
     registry_tls_verify: bool | None
 
 
@@ -273,6 +275,24 @@ def test_ee_project_build_arg_defaults_cli_invalid(
     cli_args["ee_build_arg_defaults"] = ["not-key-value"]
 
     with pytest.raises(CreatorError, match="Invalid --ee-build-arg-default"):
+        Init(Config(**cli_args))
+
+
+def test_ee_project_build_arg_defaults_cli_empty_key(
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test Init rejects KEY=VALUE when KEY is empty (e.g. ``=value``).
+
+    Args:
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "ee_empty_key")
+    cli_args["ee_build_arg_defaults"] = ["=only-a-value"]
+
+    with pytest.raises(CreatorError, match="empty key"):
         Init(Config(**cli_args))
 
 
@@ -1529,7 +1549,7 @@ def test_ee_config_from_dict_defaults() -> None:
     assert not cfg.python_deps
     assert not cfg.galaxy_servers
     assert not cfg.scm_servers
-    assert cfg.build_arg_defaults == {}
+    assert not cfg.build_arg_defaults
 
 
 def test_ee_config_from_dict_build_arg_defaults_invalid() -> None:

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -206,6 +206,88 @@ def test_run_success_ee_project_with_params(
     assert "my-custom-ee" in ee_content
 
 
+def test_run_success_ee_project_with_build_arg_defaults_cli(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test Init.run() writes build_arg_defaults from CLI.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "ee_pre")
+    cli_args["ee_build_arg_defaults"] = ["ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre"]
+
+    init = Init(Config(**cli_args))
+    init.run()
+    result = capsys.readouterr().out
+
+    assert r"Note: execution_env project created" in result
+
+    ee_file = tmp_path / "ee_pre" / "execution-environment.yml"
+    ee_content = ee_file.read_text()
+    assert "build_arg_defaults:" in ee_content
+    assert "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS" in ee_content
+    assert "--pre" in ee_content
+
+
+def test_ee_project_build_arg_defaults_cli_invalid(
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test Init rejects malformed ee_build_arg_defaults entries.
+
+    Args:
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "ee_bad_arg")
+    cli_args["ee_build_arg_defaults"] = ["not-key-value"]
+
+    with pytest.raises(CreatorError, match="Invalid --ee-build-arg-default"):
+        Init(Config(**cli_args))
+
+
+def test_ee_project_build_arg_defaults_merge_config_and_cli(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """CLI build_arg_defaults overlay values from --ee-config.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "ee_merge")
+    cli_args["ee_config"] = json.dumps(
+        {
+            "build_arg_defaults": {
+                "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": "--stable",
+                "OTHER_ARG": "x",
+            },
+        },
+    )
+    cli_args["ee_build_arg_defaults"] = ["ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre"]
+
+    init = Init(Config(**cli_args))
+    init.run()
+    assert r"Note: execution_env project created" in capsys.readouterr().out
+
+    ee_content = (tmp_path / "ee_merge" / "execution-environment.yml").read_text()
+    assert "--pre" in ee_content
+    assert "OTHER_ARG" in ee_content
+    assert "x" in ee_content
+    assert "--stable" not in ee_content
+
+
 def test_ee_project_invalid_collection_name(
     tmp_path: Path,
     cli_args: ConfigDict,
@@ -1298,6 +1380,7 @@ def test_ee_config_from_dict_full() -> None:
         "additional_build_steps": {"prepend_base": ["RUN echo hi"]},
         "options": {"package_manager_path": "/usr/bin/dnf"},
         "ansible_cfg": "[galaxy]\nserver_list = hub\n",
+        "build_arg_defaults": {"ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": "--pre"},
     }
     cfg = EEConfig.from_dict(data)
 
@@ -1311,6 +1394,7 @@ def test_ee_config_from_dict_full() -> None:
     assert cfg.additional_build_files == ({"src": "a.cfg", "dest": "configs"},)
     assert cfg.additional_build_steps == {"prepend_base": ["RUN echo hi"]}
     assert cfg.options == {"package_manager_path": "/usr/bin/dnf"}
+    assert cfg.build_arg_defaults == {"ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": "--pre"}
     assert "server_list" in cfg.ansible_cfg
     assert not cfg.galaxy_servers
 
@@ -1411,6 +1495,16 @@ def test_ee_config_from_dict_defaults() -> None:
     assert not cfg.python_deps
     assert not cfg.galaxy_servers
     assert not cfg.scm_servers
+    assert cfg.build_arg_defaults == {}
+
+
+def test_ee_config_from_dict_build_arg_defaults_invalid() -> None:
+    """Test EEConfig.from_dict rejects non-string build_arg_defaults values."""
+    with pytest.raises(CreatorError, match="build_arg_defaults"):
+        EEConfig.from_dict({"build_arg_defaults": "not-a-mapping"})
+
+    with pytest.raises(CreatorError, match="build_arg_defaults"):
+        EEConfig.from_dict({"build_arg_defaults": {"FOO": 1}})
 
 
 def test_ee_collection_from_dict_invalid_name() -> None:
@@ -1472,6 +1566,7 @@ def test_ee_config_to_schema_shape() -> None:
     assert "scm_servers" in props
     assert props["scm_servers"]["type"] == "array"
     assert "ee_file_name" in props
+    assert "build_arg_defaults" in props
 
 
 def test_ee_config_schema_in_cli_schema() -> None:


### PR DESCRIPTION

This change lets ansible-creator init execution_env emit a build_arg_defaults section in execution-environment.yml (for ansible-builder), and configure it from JSON/YAML or the CLI.


- [x] EEConfig / --ee-config / --ee-config-file: optional build_arg_defaults mapping (string keys > string values), validated in EEConfig.from_dict.
- [x] CLI: repeatable --ee-build-arg-default KEY=VALUE on init execution_env (e.g. ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre).
- [x] Merge behavior: values from --ee-build-arg-default override the same keys from file/inline config; other keys from the file are unchanged.
- [x] Template: execution-environment.yml.j2 renders build_arg_defaults only when non-empty.
- [x] Redo: CLI overlay logic moved to _ee_cli_flag_overrides to keep _build_ee_config within complexity limits.

```
uv run ansible-creator init execution_env /tmp/ee-test \
  --ee-build-arg-default ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='--pre --ignore-certs'
```