### PR TITLE
fix: add missing build stages and fix ordering in EE template

### DIFF
--- a/src/ansible_creator/resources/execution_env_project/execution-environment.yml.j2
+++ b/src/ansible_creator/resources/execution_env_project/execution-environment.yml.j2
@@ -76,6 +76,17 @@ additional_build_steps:
     - {{ step }}
 {%- endfor %}
 {%- endif %}
+{%- if not is_official_ee or ee_additional_build_steps.append_base is defined %}
+  append_base:
+{%- if not is_official_ee %}
+    - RUN $PYCMD -m pip install -U pip
+{%- endif %}
+{%- if ee_additional_build_steps.append_base is defined %}
+{%- for step in ee_additional_build_steps.append_base %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- endif %}
 {%- if ee_galaxy_token_vars or ee_additional_build_steps.prepend_galaxy is defined %}
   prepend_galaxy:
 {%- for var in ee_galaxy_token_vars %}
@@ -87,16 +98,23 @@ additional_build_steps:
 {%- endfor %}
 {%- endif %}
 {%- endif %}
-{%- if not is_official_ee or ee_additional_build_steps.append_base is defined %}
-  append_base:
-{%- if not is_official_ee %}
-    - RUN $PYCMD -m pip install -U pip
-{%- endif %}
-{%- if ee_additional_build_steps.append_base is defined %}
-{%- for step in ee_additional_build_steps.append_base %}
+{%- if ee_additional_build_steps.append_galaxy is defined %}
+  append_galaxy:
+{%- for step in ee_additional_build_steps.append_galaxy %}
     - {{ step }}
 {%- endfor %}
 {%- endif %}
+{%- if ee_additional_build_steps.prepend_builder is defined %}
+  prepend_builder:
+{%- for step in ee_additional_build_steps.prepend_builder %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_additional_build_steps.append_builder is defined %}
+  append_builder:
+{%- for step in ee_additional_build_steps.append_builder %}
+    - {{ step }}
+{%- endfor %}
 {%- endif %}
 {%- if ee_additional_build_steps.prepend_final is defined %}
   prepend_final:


### PR DESCRIPTION
- Add the missing `append_galaxy`, `prepend_builder`, and `append_builder` stages to the execution-environment.yml.j2 template.
- Reorder all `additional_build_steps` blocks to follow the correct ansible-builder v3 build stage sequence: base → galaxy → builder → final.

Closes https://redhat.atlassian.net/browse/AAP-73027
