### PR TITLE
fix: add missing blank lines in skill markdown files

### DIFF
--- a/.agents/skills/diagnose-ci/SKILL.md
+++ b/.agents/skills/diagnose-ci/SKILL.md
@@ -258,6 +258,7 @@ gh pr view PR_NUMBER --repo OWNER/REPO \
 - The fix is one of these safe categories ONLY: lockfile regeneration, formatter/linter auto-fix, removing unused imports, or adding a type annotation on a single line
 
 **NEEDS HUMAN REVIEW** — ANY of these:
+
 1. Multiple major version bumps in one PR
 2. Any major version bump that requires source code changes (not just
    lockfile/config)

--- a/.agents/skills/fix-bot-prs/SKILL.md
+++ b/.agents/skills/fix-bot-prs/SKILL.md
@@ -154,17 +154,21 @@ on the PR by `diagnose-ci`. There is nothing left to do.
 ### 4b. Apply by category
 
 **Lockfile regeneration:**
+
 ```bash
 pnpm install          # TypeScript
 uv lock               # Python
 ```
+
 Commit the regenerated lockfile.
 
 **Formatter/linter auto-fix:**
+
 ```bash
 npx prek run --all-files    # TypeScript
 tox -e lint                 # Python (some linters auto-fix)
 ```
+
 Commit any auto-formatted files.
 
 **Removing unused imports:**

--- a/.agents/skills/verify-local/SKILL.md
+++ b/.agents/skills/verify-local/SKILL.md
@@ -87,11 +87,13 @@ Use frozen/locked install to match CI:
 **TypeScript:**
 
 If `pnpm-lock.yaml` was modified (e.g., lockfile regen fix), use:
+
 ```bash
 pnpm install
 ```
 
 Otherwise:
+
 ```bash
 pnpm install --frozen-lockfile
 ```
@@ -100,11 +102,13 @@ The frozen check is CI's job. Verify-local's job is "will build/lint/pkg
 pass," not "is the lockfile in sync."
 
 **Python/tox:**
+
 ```bash
 uv sync --no-progress -q
 ```
 
 **Python/uv:**
+
 ```bash
 uv sync --no-progress -q
 ```


### PR DESCRIPTION
## Summary
- Ran `prek run --all-files` to fix markdown formatting violations causing CI lint failures on main
- Added required blank lines before/after fenced code blocks in three `.agents/skills/` markdown files

## Test plan
- [x] `uv run prek run --all-files` passes cleanly with exit code 0