### PR TITLE
fix: install python3-pip when pip module is missing

### DIFF
--- a/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
+++ b/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
@@ -200,7 +200,7 @@ build:
   before_script:
     - |
       echo -e "\e[0Ksection_start:$(date +%s):setup_python[collapsed=true]\r\e[0KSetup Python and ansible-builder"
-      if ! command -v python3 &> /dev/null; then
+      if ! command -v python3 &> /dev/null || ! python3 -m pip --version &> /dev/null; then
         if command -v dnf &> /dev/null; then
           dnf install -y python3 python3-pip
         elif command -v apt-get &> /dev/null; then

--- a/tests/fixtures/common/ee-ci/.gitlab-ci.yml
+++ b/tests/fixtures/common/ee-ci/.gitlab-ci.yml
@@ -168,7 +168,7 @@ build:
   before_script:
     - |
       echo -e "\e[0Ksection_start:$(date +%s):setup_python[collapsed=true]\r\e[0KSetup Python and ansible-builder"
-      if ! command -v python3 &> /dev/null; then
+      if ! command -v python3 &> /dev/null || ! python3 -m pip --version &> /dev/null; then
         if command -v dnf &> /dev/null; then
           dnf install -y python3 python3-pip
         elif command -v apt-get &> /dev/null; then

--- a/tests/fixtures/project/ee_project_gitlab/.gitlab-ci.yml
+++ b/tests/fixtures/project/ee_project_gitlab/.gitlab-ci.yml
@@ -168,7 +168,7 @@ build:
   before_script:
     - |
       echo -e "\e[0Ksection_start:$(date +%s):setup_python[collapsed=true]\r\e[0KSetup Python and ansible-builder"
-      if ! command -v python3 &> /dev/null; then
+      if ! command -v python3 &> /dev/null || ! python3 -m pip --version &> /dev/null; then
         if command -v dnf &> /dev/null; then
           dnf install -y python3 python3-pip
         elif command -v apt-get &> /dev/null; then


### PR DESCRIPTION
## Description
- Fix gitlab CI template to check for both `python3` and `python3-pip` before skipping package installation
- The `quay.io/podman/stable` runner image ships `python3` without `pip`, so the previous check (`command -v python3`) passed and skipped the `dnf install`, causing the build job to fail with `No module named pip`
- Updated condition to:
`if ! command -v python3 || ! python3 -m pip --version; then`

## Test plan
- [x] All unit tests pass
- [x] Verified fix on gitlab runner - [#2597640795](https://gitlab.com/test-rhaap-portal/gitlab-ci-test/-/pipelines/2597640795)