### PR TITLE
feat(schema): include validation metadata in schema output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -191,11 +191,18 @@ Each node in the schema tree follows this structure:
     "type": "object",
     "properties": {
       "param_name": {
-        "type": "string|boolean|int|array",
+        "type": "string|boolean|integer|int|array",
         "description": "Parameter help text",
         "default": "default-value",
         "aliases": ["--flag", "-f"],
-        "enum": ["choice1", "choice2"]
+        "enum": ["choice1", "choice2"],
+        "minLength": 2,
+        "pattern": "^[a-z]+$",
+        "format": "fqcn",
+        "minimum": 0,
+        "maximum": 5,
+        "minItems": 0,
+        "items": { "type": "string" }
       }
     },
     "required": ["param_name"]
@@ -209,9 +216,23 @@ Each node in the schema tree follows this structure:
 **Parameter types** are inferred from the argparse actions:
 
 - `"string"` — default for most arguments
-- `"boolean"` — for store-true / store-false flags
+- `"boolean"` — for store-true / store-false flags and `BooleanOptionalAction`
+- `"integer"` — for count actions (e.g. verbosity)
 - `"int"` / `"float"` — when a type converter is specified
 - `"array"` — for nargs `+` or `*`
+
+**Validation keywords** are optional fields that provide standard JSON Schema
+constraints.  Consumers can use them for client-side validation; fields that are
+absent carry no constraint.  All keywords are standard JSON Schema:
+
+| Keyword               | Applies to | Purpose                                  |
+| --------------------- | ---------- | ---------------------------------------- |
+| `minLength`/`maxLength` | string   | Minimum / maximum character count        |
+| `pattern`             | string     | Regex for format validation              |
+| `format`              | string     | Semantic hint (`path`, `url`, `fqcn`)    |
+| `minimum`/`maximum`   | integer    | Numeric range                            |
+| `minItems`/`maxItems` | array      | Array length constraints                 |
+| `items`               | array      | Schema for individual array elements     |
 
 **Routing parameters** (`subcommand`, `project`, `type`, `resource_type`,
 `plugin_type`) are excluded from the schema — they are implicit in the command

--- a/src/ansible_creator/_arg_parser_custom.py
+++ b/src/ansible_creator/_arg_parser_custom.py
@@ -87,23 +87,26 @@ class CustomArgumentParser(argparse.ArgumentParser):
         if sys.version_info < (3, 14):  # pragma: no cover py>=3.14
             self.formatter_class = CustomHelpFormatter
 
-    def add_argument(  # type: ignore[override]
+    def add_argument(
         self,
         *args: Any,  # noqa: ANN401
         **kwargs: Any,  # noqa: ANN401
-    ) -> None:
+    ) -> argparse.Action:
         """Add an argument.
 
         Args:
             *args: The arguments
             **kwargs: The keyword arguments
+
+        Returns:
+            The created argparse Action.
         """
         if sys.version_info < (3, 14):  # pragma: no cover py>=3.14
             if "choices" in kwargs:  # pragma: no cover py>=3.14
                 kwargs["help"] += f" (choices: {', '.join(kwargs['choices'])})"
             if "default" in kwargs and kwargs["default"] != "==SUPPRESS==":
                 kwargs["help"] += f" (default: {kwargs['default']})"
-        super().add_argument(*args, **kwargs)
+        return super().add_argument(*args, **kwargs)
 
     def add_argument_group(
         self,

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -189,13 +189,14 @@ class Parser:
             help="Disable the use of ANSI codes for terminal color.",
         )
 
-        parser.add_argument(
+        log_file_action = parser.add_argument(
             "--lf",
             "--log-file <file>",
             dest="log_file",
             default=str(Path.cwd() / "ansible-creator.log"),
             help="Log file to write to.",
         )
+        log_file_action.schema_metadata = {"format": "path"}  # type: ignore[attr-defined]
 
         parser.add_argument(
             "--ll",
@@ -223,7 +224,7 @@ class Parser:
             help="Output messages as JSON",
         )
 
-        parser.add_argument(
+        verbose_action = parser.add_argument(
             "-v",
             "--verbosity",
             dest="verbose",
@@ -231,6 +232,7 @@ class Parser:
             default=0,
             help="Give more Cli output. Option is additive, and can be used up to 3 times.",
         )
+        verbose_action.schema_metadata = {"minimum": 0, "maximum": 3}  # type: ignore[attr-defined]
 
     def _add_args_init_common(self, parser: argparse.ArgumentParser) -> None:
         """Add common init arguments to the parser.
@@ -665,12 +667,17 @@ class Parser:
             "collection",
             help="Create a new Ansible collection project.",
         )
-        parser.add_argument(
+        collection_action = parser.add_argument(
             "collection",
             help="The collection name in the format '<namespace>.<name>'.",
             metavar="collection-name",
             type=self._valid_collection_name,
         )
+        collection_action.schema_metadata = {  # type: ignore[attr-defined]
+            "pattern": r"^(?!_)[a-z0-9_]+\.(?!_)[a-z0-9_]+$",
+            "minLength": (MIN_COLLECTION_NAME_LEN + 1) * 2 + 1,
+            "format": "fqcn",
+        }
         parser.add_argument(
             "init_path",
             default="./",
@@ -695,13 +702,18 @@ class Parser:
             help="Create a new Ansible playbook project.",
         )
 
-        parser.add_argument(
+        collection_action = parser.add_argument(
             "collection",
             help="The name for the playbook adjacent collection in the format"
             " '<namespace>.<name>'.",
             metavar="collection-name",
             type=self._valid_collection_name,
         )
+        collection_action.schema_metadata = {  # type: ignore[attr-defined]
+            "pattern": r"^(?!_)[a-z0-9_]+\.(?!_)[a-z0-9_]+$",
+            "minLength": (MIN_COLLECTION_NAME_LEN + 1) * 2 + 1,
+            "format": "fqcn",
+        }
 
         parser.add_argument(
             "init_path",
@@ -743,22 +755,26 @@ class Parser:
             'Example: --ee-config \'{"base_image": "...", "collections": [...]}\'',
         )
         ee_config_action.schema_class = EEConfig  # type: ignore[attr-defined]
-        ee_config_group.add_argument(
+        ee_config_file_action = ee_config_group.add_argument(
             "--ee-config-file",
             dest="ee_config_file",
             metavar="FILE",
             help="Path to a JSON/YAML config file containing EE parameters. "
             "See documentation for the expected schema.",
         )
+        ee_config_file_action.schema_metadata = {"format": "path"}  # type: ignore[attr-defined]
 
-        parser.add_argument(
+        base_image_action = parser.add_argument(
             "--ee-base-image",
             dest="base_image",
             default="quay.io/fedora/fedora:41",
             help="Base image for the execution environment. Default: quay.io/fedora/fedora:41",
         )
+        base_image_action.schema_metadata = {  # type: ignore[attr-defined]
+            "minLength": 1,
+        }
 
-        parser.add_argument(
+        ee_collections_action = parser.add_argument(
             "--ee-collections",
             dest="ee_collections",
             action="append",
@@ -769,6 +785,10 @@ class Parser:
             "Example: --ee-collections ansible.posix --ee-collections 'ansible.utils:>=1.0.0' "
             "--ee-collections 'my.collection:1.0.0:galaxy:https://galaxy.ansible.com'",
         )
+        ee_collections_action.schema_metadata = {  # type: ignore[attr-defined]
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 0,
+        }
 
         parser.add_argument(
             "--ee-python-deps",
@@ -790,13 +810,14 @@ class Parser:
             "Example: --ee-system-packages openssh-clients --ee-system-packages sshpass",
         )
 
-        parser.add_argument(
+        ee_name_action = parser.add_argument(
             "--ee-name",
             default="ansible_sample_ee",
             help="Name/tag for the execution environment image. Default: ansible_sample_ee",
         )
+        ee_name_action.schema_metadata = {"minLength": 1}  # type: ignore[attr-defined]
 
-        parser.add_argument(
+        ee_file_name_action = parser.add_argument(
             "--ee-file-name",
             dest="ee_file_name",
             default="execution-environment.yml",
@@ -804,6 +825,10 @@ class Parser:
             help="Name of the EE definition file. "
             "Must end with .yml or .yaml. Default: execution-environment.yml",
         )
+        ee_file_name_action.schema_metadata = {  # type: ignore[attr-defined]
+            "pattern": r"^[^/\\]*\.(yml|yaml)$",
+            "minLength": 5,
+        }
 
         parser.add_argument(
             "--ee-build-arg-default",

--- a/src/ansible_creator/schema.py
+++ b/src/ansible_creator/schema.py
@@ -128,15 +128,17 @@ def _extract_action_info(action: argparse.Action) -> dict[str, Any]:
     the full ``EEConfig.to_schema()`` structure so that consumers (e.g.
     the ADT server) know the expected JSON shape.
 
+    If the action carries a ``schema_metadata`` dict attribute, its
+    entries (standard JSON Schema validation keywords such as
+    ``minLength``, ``pattern``, ``minimum``, ``format``, etc.) are merged
+    into the output.
+
     Args:
         action: The argparse action to extract info from.
 
     Returns:
         Dictionary with parameter type, description, and other metadata.
     """
-    # If the argparse action carries a schema_class attribute (a dataclass
-    # with a to_schema() classmethod), use it to expose the structured
-    # payload shape instead of a flat "type: string".
     schema_cls = getattr(action, "schema_class", None)
     if schema_cls is not None:
         structured: dict[str, Any] = schema_cls.to_schema()
@@ -149,37 +151,58 @@ def _extract_action_info(action: argparse.Action) -> dict[str, Any]:
         "description": _clean_help_text(action.help or ""),
     }
 
-    # Determine type
+    info.update(_infer_type(action))
+
+    if action.default is not None and action.default != argparse.SUPPRESS:
+        info["default"] = action.default
+
+    if action.option_strings:
+        info["aliases"] = list(action.option_strings)
+
+    schema_metadata: dict[str, Any] | None = getattr(action, "schema_metadata", None)
+    if schema_metadata:
+        info.update(schema_metadata)
+
+    return info
+
+
+def _infer_type(action: argparse.Action) -> dict[str, Any]:
+    """Infer JSON Schema type information from an argparse action.
+
+    Args:
+        action: The argparse action to inspect.
+
+    Returns:
+        Dictionary with ``type`` and optionally ``enum`` or ``items``.
+    """
     if action.choices:
-        info["type"] = "string"
-        info["enum"] = list(action.choices)
-    elif isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction)):  # noqa: SLF001
-        info["type"] = "boolean"
-    elif action.type:
+        return {"type": "string", "enum": list(action.choices)}
+
+    if isinstance(
+        action,
+        (
+            argparse._StoreTrueAction,  # noqa: SLF001
+            argparse._StoreFalseAction,  # noqa: SLF001
+            argparse.BooleanOptionalAction,
+        ),
+    ):
+        return {"type": "boolean"}
+
+    if isinstance(action, argparse._CountAction):  # noqa: SLF001
+        return {"type": "integer"}
+
+    if action.type:
         type_name = getattr(action.type, "__name__", str(action.type))
-        if type_name in ("int", "float"):
-            info["type"] = type_name
-        else:
-            info["type"] = "string"
-    elif (
+        return {"type": type_name if type_name in ("int", "float") else "string"}
+
+    if (
         isinstance(action, argparse._AppendAction)  # noqa: SLF001
         or action.nargs in ("+", "*")
         or (isinstance(action.nargs, int) and action.nargs > 1)
     ):
-        info["type"] = "array"
-        info["items"] = {"type": "string"}
-    else:
-        info["type"] = "string"
+        return {"type": "array", "items": {"type": "string"}}
 
-    # Add default if present and not suppressed
-    if action.default is not None and action.default != argparse.SUPPRESS:
-        info["default"] = action.default
-
-    # Add aliases (option strings)
-    if action.option_strings:
-        info["aliases"] = list(action.option_strings)
-
-    return info
+    return {"type": "string"}
 
 
 def _is_required(action: argparse.Action) -> bool:

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -292,7 +292,7 @@ class GalaxyServer:
                         "Used in [galaxy_server.<id>] and "
                         "ANSIBLE_GALAXY_SERVER_<ID>_TOKEN env var."
                     ),
-                    "pattern": r"^[a-z_][a-z0-9_]*$",
+                    "pattern": GALAXY_SERVER_ID_RE.pattern,
                     "minLength": 1,
                 },
                 "url": {
@@ -414,7 +414,7 @@ class ScmServer:
                         "Server identifier (e.g. github_org1, internal_gitlab). "
                         "Must be lowercase letters, numbers, and underscores."
                     ),
-                    "pattern": r"^[a-z_][a-z0-9_]*$",
+                    "pattern": GALAXY_SERVER_ID_RE.pattern,
                     "minLength": 1,
                 },
                 "hostname": {
@@ -429,7 +429,7 @@ class ScmServer:
                         "Must be uppercase (e.g. GITHUB_ORG1_TOKEN). "
                         "This name is used as the GitHub Actions secret name."
                     ),
-                    "pattern": r"^[A-Z][A-Z0-9_]*$",
+                    "pattern": ENV_VAR_RE.pattern,
                     "minLength": 1,
                 },
             },

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -169,6 +169,7 @@ class EECollection:
                 "name": {
                     "type": "string",
                     "description": "Collection name (namespace.name) or Git URL",
+                    "minLength": 1,
                 },
                 "version": {
                     "type": "string",
@@ -184,6 +185,7 @@ class EECollection:
                 "source": {
                     "type": "string",
                     "description": "Collection source URL",
+                    "format": "url",
                     "default": "",
                 },
             },
@@ -290,15 +292,20 @@ class GalaxyServer:
                         "Used in [galaxy_server.<id>] and "
                         "ANSIBLE_GALAXY_SERVER_<ID>_TOKEN env var."
                     ),
+                    "pattern": r"^[a-z_][a-z0-9_]*$",
+                    "minLength": 1,
                 },
                 "url": {
                     "type": "string",
                     "description": "Galaxy server content URL",
+                    "format": "url",
+                    "minLength": 1,
                 },
                 "auth_url": {
                     "type": "string",
                     "default": "",
                     "description": "SSO/OAuth token endpoint",
+                    "format": "url",
                 },
                 "token_required": {
                     "type": "boolean",
@@ -407,10 +414,13 @@ class ScmServer:
                         "Server identifier (e.g. github_org1, internal_gitlab). "
                         "Must be lowercase letters, numbers, and underscores."
                     ),
+                    "pattern": r"^[a-z_][a-z0-9_]*$",
+                    "minLength": 1,
                 },
                 "hostname": {
                     "type": "string",
                     "description": "Git server hostname (e.g. github.com)",
+                    "minLength": 1,
                 },
                 "token_env_var": {
                     "type": "string",
@@ -419,6 +429,8 @@ class ScmServer:
                         "Must be uppercase (e.g. GITHUB_ORG1_TOKEN). "
                         "This name is used as the GitHub Actions secret name."
                     ),
+                    "pattern": r"^[A-Z][A-Z0-9_]*$",
+                    "minLength": 1,
                 },
             },
         }
@@ -600,11 +612,13 @@ class EEConfig:
                     "type": "string",
                     "default": "ansible_sample_ee",
                     "description": "Name/tag for the EE image",
+                    "minLength": 1,
                 },
                 "base_image": {
                     "type": "string",
                     "default": "quay.io/fedora/fedora:41",
                     "description": "Base container image",
+                    "minLength": 1,
                 },
                 "registry": {
                     "type": "string",
@@ -612,6 +626,7 @@ class EEConfig:
                     "description": (
                         "Container registry hostname for the CI workflow (e.g. ghcr.io, quay.io)"
                     ),
+                    "minLength": 1,
                 },
                 "registry_tls_verify": {
                     "type": "boolean",
@@ -633,16 +648,19 @@ class EEConfig:
                     "type": "array",
                     "items": EECollection.to_schema(),
                     "description": "Ansible collections to include",
+                    "minItems": 0,
                 },
                 "python_deps": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"type": "string", "minLength": 1},
                     "description": "Python package dependencies",
+                    "minItems": 0,
                 },
                 "system_packages": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"type": "string", "minLength": 1},
                     "description": "System packages to install",
+                    "minItems": 0,
                 },
                 "additional_build_files": {
                     "type": "array",
@@ -677,6 +695,7 @@ class EEConfig:
                         "Galaxy server entries for ansible.cfg generation "
                         "and workflow token plumbing"
                     ),
+                    "minItems": 0,
                 },
                 "scm_servers": {
                     "type": "array",
@@ -685,11 +704,14 @@ class EEConfig:
                         "SCM server entries for private Git collection "
                         "repositories and workflow token plumbing"
                     ),
+                    "minItems": 0,
                 },
                 "ee_file_name": {
                     "type": "string",
                     "description": "Name of the EE definition file",
                     "default": "execution-environment.yml",
+                    "pattern": r"^[^/\\]*\.(yml|yaml)$",
+                    "minLength": 5,
                 },
             },
         }

--- a/tests/units/test_api.py
+++ b/tests/units/test_api.py
@@ -1036,3 +1036,96 @@ def test_run_init_collection_with_exclude(creator_api: V1, tmp_path: Path) -> No
     assert (target / ".gitignore").exists()
     assert not (target / "AGENTS.md").exists()
     assert not (target / "devfile.yaml").exists()
+
+
+def test_schema_extract_count_action_type() -> None:
+    """Test _extract_action_info handles action='count' as integer type."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Verbosity")
+    action = next(a for a in parser._actions if a.dest == "verbose")
+    info = _extract_action_info(action)
+    assert info["type"] == "integer"
+
+
+def test_schema_extract_boolean_optional_action() -> None:
+    """Test _extract_action_info handles BooleanOptionalAction as boolean type."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--flag",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="A flag",
+    )
+    action = next(a for a in parser._actions if a.dest == "flag")
+    info = _extract_action_info(action)
+    assert info["type"] == "boolean"
+
+
+def test_schema_extract_schema_metadata() -> None:
+    """Test _extract_action_info merges schema_metadata into output."""
+    parser = argparse.ArgumentParser()
+    expected_min_length = 3
+    act = parser.add_argument("--name", help="A name")
+    act.schema_metadata = {  # type: ignore[attr-defined]
+        "minLength": expected_min_length,
+        "pattern": "^[a-z]+$",
+        "format": "fqcn",
+    }
+    action = next(a for a in parser._actions if a.dest == "name")
+    info = _extract_action_info(action)
+    assert info["minLength"] == expected_min_length
+    assert info["pattern"] == "^[a-z]+$"
+    assert info["format"] == "fqcn"
+    assert info["type"] == "string"
+
+
+def test_schema_validation_metadata_on_collection() -> None:
+    """Test that collection parameter includes validation metadata."""
+    from ansible_creator.schema import for_command  # noqa: PLC0415
+
+    schema = for_command("init", "collection")
+    props = schema["parameters"]["properties"]
+    assert "collection" in props
+    col = props["collection"]
+    assert "pattern" in col
+    assert "minLength" in col
+    assert col["format"] == "fqcn"
+    expected_min_length = 7
+    assert col["minLength"] == expected_min_length
+
+
+def test_schema_validation_metadata_on_verbosity() -> None:
+    """Test that verbose parameter includes integer type and min/max."""
+    from ansible_creator.schema import for_command  # noqa: PLC0415
+
+    schema = for_command("init", "collection")
+    props = schema["parameters"]["properties"]
+    assert "verbose" in props
+    verbose = props["verbose"]
+    assert verbose["type"] == "integer"
+    assert verbose["minimum"] == 0
+    expected_max = 3
+    assert verbose["maximum"] == expected_max
+
+
+def test_schema_validation_metadata_on_ee_file_name() -> None:
+    """Test that ee_file_name parameter includes pattern and minLength."""
+    from ansible_creator.schema import for_command  # noqa: PLC0415
+
+    schema = for_command("init", "execution_env")
+    props = schema["parameters"]["properties"]
+    assert "ee_file_name" in props
+    ee_fn = props["ee_file_name"]
+    assert "pattern" in ee_fn
+    expected_min_length = 5
+    assert ee_fn["minLength"] == expected_min_length
+
+
+def test_schema_validation_metadata_on_registry_tls_verify() -> None:
+    """Test that registry_tls_verify is detected as boolean type."""
+    from ansible_creator.schema import for_command  # noqa: PLC0415
+
+    schema = for_command("init", "execution_env")
+    props = schema["parameters"]["properties"]
+    assert "registry_tls_verify" in props
+    assert props["registry_tls_verify"]["type"] == "boolean"

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -1971,6 +1971,51 @@ def test_scm_server_to_schema() -> None:
     assert "token_env_var" in props
 
 
+def test_scm_server_to_schema_validation_metadata() -> None:
+    """Test ScmServer.to_schema includes validation constraints."""
+    schema = ScmServer.to_schema()
+    props = schema["properties"]
+    assert props["id"]["pattern"] == r"^[a-z_][a-z0-9_]*$"
+    assert props["id"]["minLength"] == 1
+    assert props["hostname"]["minLength"] == 1
+    assert props["token_env_var"]["pattern"] == r"^[A-Z][A-Z0-9_]*$"
+    assert props["token_env_var"]["minLength"] == 1
+
+
+def test_galaxy_server_to_schema_validation_metadata() -> None:
+    """Test GalaxyServer.to_schema includes validation constraints."""
+    schema = GalaxyServer.to_schema()
+    props = schema["properties"]
+    assert props["id"]["pattern"] == r"^[a-z_][a-z0-9_]*$"
+    assert props["id"]["minLength"] == 1
+    assert props["url"]["format"] == "url"
+    assert props["url"]["minLength"] == 1
+    assert props["auth_url"]["format"] == "url"
+
+
+def test_ee_collection_to_schema_validation_metadata() -> None:
+    """Test EECollection.to_schema includes validation constraints."""
+    schema = EECollection.to_schema()
+    props = schema["properties"]
+    assert props["name"]["minLength"] == 1
+    assert props["source"]["format"] == "url"
+
+
+def test_ee_config_to_schema_validation_metadata() -> None:
+    """Test EEConfig.to_schema includes validation constraints."""
+    schema = EEConfig.to_schema()
+    props = schema["properties"]
+    assert props["ee_name"]["minLength"] == 1
+    assert props["base_image"]["minLength"] == 1
+    assert props["registry"]["minLength"] == 1
+    assert props["collections"]["minItems"] == 0
+    assert props["python_deps"]["items"]["minLength"] == 1
+    assert props["system_packages"]["items"]["minLength"] == 1
+    assert props["ee_file_name"]["pattern"] == r"^[^/\\]*\.(yml|yaml)$"
+    expected_ee_file_min_len = 5
+    assert props["ee_file_name"]["minLength"] == expected_ee_file_min_len
+
+
 def test_ee_config_from_dict_scm_servers() -> None:
     """Test EEConfig.from_dict parses scm_servers list."""
     data = {


### PR DESCRIPTION
## Summary
- Extend `ansible-creator schema` output with standard JSON Schema validation keywords so consumers (VS Code extension, MCP server, Navita) get correct validation automatically for all current and future commands without maintaining hardcoded overrides.

## Changes
- Add `schema_metadata` attribute mechanism on argparse actions for attaching validation constraints (`minLength`, `pattern`, `format`, `minimum`, `maximum`, `minItems`, `items`)
- Extract `_infer_type()` helper from `_extract_action_info()` to reduce cyclomatic complexity
- Detect `action="count"` as `type: "integer"` and `BooleanOptionalAction` as `type: "boolean"` (previously both fell through to `type: "string"`)
- Annotate CLI arguments with validation constraints:
  - `collection` name: `pattern`, `minLength: 7`, `format: "fqcn"`
  - `verbose`: `minimum: 0`, `maximum: 3`
  - `ee_file_name`: `pattern: "^[^/\\]*\\.(yml|yaml)$"`, `minLength: 5`
  - `ee_base_image`, `ee_name`: `minLength: 1`
  - `ee_collections`: `items` with `minLength`, `minItems: 0`
  - `log_file`, `ee_config_file`: `format: "path"`
- Enrich `to_schema()` on `EECollection`, `GalaxyServer`, `ScmServer`, `EEConfig` with `pattern`, `minLength`, `format`, and `minItems` on relevant fields
- Fix `CustomArgumentParser.add_argument()` to return the `Action` (was returning `None`)
- Update API docs to describe new validation keywords

All new fields are optional additions — consumers that don't understand them simply ignore them. No breaking change.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e py` passes (269 passed, 100% coverage)
- [x] Docs updated (`docs/api.md`)

## Attribution
Human-led and reviewed, AI-assisted.

Fixes #602