### PR TITLE
fix: install gettext when envsubst is missing on gitlab CI

### DIFF
--- a/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
+++ b/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
@@ -253,8 +253,14 @@ build:
 {%- if ee_scm_token_vars %}
 
       if ! command -v envsubst >/dev/null 2>&1; then
-        echo "ERROR: envsubst not found; required for SCM token substitution. Install gettext (or gettext-base)."
-        exit 1
+        if command -v dnf &> /dev/null; then
+          dnf install -y gettext
+        elif command -v apt-get &> /dev/null; then
+          apt-get update && apt-get install -y gettext-base
+        else
+          echo "ERROR: envsubst not found; required for SCM token substitution. Install gettext (or gettext-base)."
+          exit 1
+        fi
       fi
       if [ -f context/_build/requirements.yml ]; then
         envsubst '{% for var in ee_scm_token_vars %}${{ var }}{% if not loop.last %} {% endif %}{% endfor %}' \


### PR DESCRIPTION
## Summary
- Auto install `gettext` (dnf) or `gettext-base` (apt) when `envsubst` is missing instead of exiting with an error. This is  needed for SCM token substitution in private collection Git URLs on runner images like `quay.io/podman/stable` that don't ship it.

## Testing
- All 83 EE init unit tests pass locally
- Validated on gitlab.com runners:
  - Before fix: https://gitlab.com/test-rhaap-portal/git-ee-dep/-/jobs/14947663966
  - After fix: https://gitlab.com/test-rhaap-portal/git-ee-dep/-/jobs/14947813525