### PR TITLE
fix: add IMAGE_BUILD_TAG variable to GitLab CI pipeline template

### DIFF
--- a/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
+++ b/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
@@ -66,6 +66,7 @@ variables:
   EE_DIR: "."
   EE_FILE_NAME: "{{ ee_file_name }}"
   EE_REGISTRY_TLS_VERIFY: "{{ ee_registry_tls_verify | lower }}"
+  IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
   IMAGE_WARN_AGE: "40"
   IMAGE_FAIL_AGE: "80"
   SKIP_BASE_IMAGE_VALIDATION: "false"
@@ -291,16 +292,16 @@ build:
       # shellcheck disable=SC2086
       podman build --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" $EXTRA_ARGS \
-        --tag "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+        --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         --file context/Containerfile \
         context/
       echo -e "\e[0Ksection_end:$(date +%s):build_image\r\e[0K"
 
     - |
       echo -e "\e[0Ksection_start:$(date +%s):test_ee\r\e[0KTesting EE"
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         ansible --version
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         ansible-galaxy collection list || true
       echo -e "\e[0Ksection_end:$(date +%s):test_ee\r\e[0K"
 
@@ -308,7 +309,7 @@ build:
       podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         --digestfile /tmp/digest \
-        "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}"
+        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
       echo "IMAGE_DIGEST=$(cat /tmp/digest)" >> build.env
   artifacts:
     reports:
@@ -341,7 +342,7 @@ release:
       VERSION="$CI_COMMIT_TAG"
       podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}"
+        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
 
       if podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
@@ -355,7 +356,7 @@ release:
       fi
 
       for TAG in "$VERSION" "latest" "prd"; do
-        podman tag "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+        podman tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
           "${REGISTRY}/${IMAGE_NAME}:${TAG}"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
@@ -408,6 +409,7 @@ summary:
         echo "### Image Details"
         echo "- Registry: \`${REGISTRY}\`"
         echo "- Image: \`${IMAGE_NAME}\`"
+        echo "- Tag: \`${IMAGE_BUILD_TAG}\`"
         echo "- EE Directory: \`${EE_DIR}\`"
         if [ -n "$IMAGE_DIGEST" ]; then
           echo "- Digest: \`${IMAGE_DIGEST}\`"

--- a/tests/fixtures/common/ee-ci/.gitlab-ci.yml
+++ b/tests/fixtures/common/ee-ci/.gitlab-ci.yml
@@ -56,6 +56,7 @@ variables:
   EE_DIR: "."
   EE_FILE_NAME: "execution-environment.yml"
   EE_REGISTRY_TLS_VERIFY: "true"
+  IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
   IMAGE_WARN_AGE: "40"
   IMAGE_FAIL_AGE: "80"
   SKIP_BASE_IMAGE_VALIDATION: "false"
@@ -230,16 +231,16 @@ build:
       # shellcheck disable=SC2086
       podman build --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" $EXTRA_ARGS \
-        --tag "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+        --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         --file context/Containerfile \
         context/
       echo -e "\e[0Ksection_end:$(date +%s):build_image\r\e[0K"
 
     - |
       echo -e "\e[0Ksection_start:$(date +%s):test_ee\r\e[0KTesting EE"
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         ansible --version
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         ansible-galaxy collection list || true
       echo -e "\e[0Ksection_end:$(date +%s):test_ee\r\e[0K"
 
@@ -247,7 +248,7 @@ build:
       podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         --digestfile /tmp/digest \
-        "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}"
+        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
       echo "IMAGE_DIGEST=$(cat /tmp/digest)" >> build.env
   artifacts:
     reports:
@@ -280,7 +281,7 @@ release:
       VERSION="$CI_COMMIT_TAG"
       podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}"
+        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
 
       if podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
@@ -294,7 +295,7 @@ release:
       fi
 
       for TAG in "$VERSION" "latest" "prd"; do
-        podman tag "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+        podman tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
           "${REGISTRY}/${IMAGE_NAME}:${TAG}"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
@@ -347,6 +348,7 @@ summary:
         echo "### Image Details"
         echo "- Registry: \`${REGISTRY}\`"
         echo "- Image: \`${IMAGE_NAME}\`"
+        echo "- Tag: \`${IMAGE_BUILD_TAG}\`"
         echo "- EE Directory: \`${EE_DIR}\`"
         if [ -n "$IMAGE_DIGEST" ]; then
           echo "- Digest: \`${IMAGE_DIGEST}\`"

--- a/tests/fixtures/project/ee_project_gitlab/.gitlab-ci.yml
+++ b/tests/fixtures/project/ee_project_gitlab/.gitlab-ci.yml
@@ -56,6 +56,7 @@ variables:
   EE_DIR: "."
   EE_FILE_NAME: "execution-environment.yml"
   EE_REGISTRY_TLS_VERIFY: "true"
+  IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
   IMAGE_WARN_AGE: "40"
   IMAGE_FAIL_AGE: "80"
   SKIP_BASE_IMAGE_VALIDATION: "false"
@@ -230,16 +231,16 @@ build:
       # shellcheck disable=SC2086
       podman build --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" $EXTRA_ARGS \
-        --tag "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+        --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         --file context/Containerfile \
         context/
       echo -e "\e[0Ksection_end:$(date +%s):build_image\r\e[0K"
 
     - |
       echo -e "\e[0Ksection_start:$(date +%s):test_ee\r\e[0KTesting EE"
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         ansible --version
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
         ansible-galaxy collection list || true
       echo -e "\e[0Ksection_end:$(date +%s):test_ee\r\e[0K"
 
@@ -247,7 +248,7 @@ build:
       podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         --digestfile /tmp/digest \
-        "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}"
+        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
       echo "IMAGE_DIGEST=$(cat /tmp/digest)" >> build.env
   artifacts:
     reports:
@@ -280,7 +281,7 @@ release:
       VERSION="$CI_COMMIT_TAG"
       podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}"
+        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
 
       if podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
@@ -294,7 +295,7 @@ release:
       fi
 
       for TAG in "$VERSION" "latest" "prd"; do
-        podman tag "${REGISTRY}/${IMAGE_NAME}:build-${CI_COMMIT_SHA}" \
+        podman tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
           "${REGISTRY}/${IMAGE_NAME}:${TAG}"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
@@ -347,6 +348,7 @@ summary:
         echo "### Image Details"
         echo "- Registry: \`${REGISTRY}\`"
         echo "- Image: \`${IMAGE_NAME}\`"
+        echo "- Tag: \`${IMAGE_BUILD_TAG}\`"
         echo "- EE Directory: \`${EE_DIR}\`"
         if [ -n "$IMAGE_DIGEST" ]; then
           echo "- Digest: \`${IMAGE_DIGEST}\`"


### PR DESCRIPTION
## Description

- Add `IMAGE_BUILD_TAG` CI variable to the `.gitlab-ci.yml.j2` template with a default of `build-${CI_COMMIT_SHA}`
- Replace all hardcoded `build-${CI_COMMIT_SHA}` tag references with `${IMAGE_BUILD_TAG}` in build, test, push, release, and summary jobs
- Add tag info to the pipeline summary output
- Update test fixtures to match

This brings the Gitlab CI template to parity with the Github Actions workflow (`ee-build.yml.j2`), which already supports overriding the image build tag via `workflow_dispatch` inputs.

## Why

The image build tag was hardcoded to `build-<SHA>` with no way to override it at runtime. Unlike the GitHub Actions workflow which accepts `image_build_tag` as a `workflow_dispatch` input, the Gitlab CI template had no equivalent variable. This made it impossible for API consumers, web triggers, or upstream pipelines to specify a custom image tag since builds always produced `build-<SHA>` regardless of what was requested.

## Tests

- [x] Tested by triggering pipelines using the gitlab API at https://gitlab.com/test-rhaap-portal/local-build-test

  - Pipeline: https://gitlab.com/test-rhaap-portal/local-build-test/-/pipelines/2637167492