### PR TITLE
refactor: align CI variable naming with consistent EE_ prefix

### DIFF
--- a/docs/ee_scaffolding.md
+++ b/docs/ee_scaffolding.md
@@ -481,7 +481,7 @@ in image history.
 The pipeline uses a single `REGISTRY_AUTHFILE` under the project directory
 for `podman login`, `podman build`, and `podman push`, so registries that
 require authentication on layer/blob checks (e.g. Quay.io) succeed.
-`IMAGE_NAME` is lowercased before tagging and pushing because many OCI
+`EE_IMAGE_NAME` is lowercased before tagging and pushing because many OCI
 registries reject mixed-case repository paths.
 
 ### Token security

--- a/src/ansible_creator/resources/common/ee-ci/.github/workflows/ee-build.yml.j2
+++ b/src/ansible_creator/resources/common/ee-ci/.github/workflows/ee-build.yml.j2
@@ -57,12 +57,12 @@ on:
         required: false
         default: "{{ ee_image_name }}"
         type: string
-      registry_tls_verify:
+      ee_registry_tls_verify:
         description: "Verify TLS certificates for container registries (true/false)"
         required: false
         default: "{{ ee_registry_tls_verify | lower }}"
         type: string
-      image_build_tag:
+      ee_image_build_tag:
         description: "Custom image tag for the build (defaults to build-<commit SHA>)"
         required: false
         type: string
@@ -78,23 +78,23 @@ permissions:
   packages: write
 
 {% raw %}# Prevent concurrent builds from racing to push the same image tag.
-# A static custom tag (e.g. vars.IMAGE_BUILD_TAG=test) dispatched on
+# A static custom tag (e.g. vars.EE_IMAGE_BUILD_TAG=test) dispatched on
 # different refs would otherwise land in separate groups yet push to
 # the same registry tag. Including the resolved tag serialises them.
 concurrency:
-  group: ee-build-${{ github.ref }}-${{ inputs.image_build_tag || vars.IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  group: ee-build-${{ github.ref }}-${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
   cancel-in-progress: false
 {% endraw %}
 env:
   # Container registry configuration (override via repository Variables)
-  REGISTRY: {% raw %}${{ inputs.ee_registry || vars.EE_REGISTRY || '{% endraw %}{{ ee_registry }}{% raw %}' }}{% endraw %}
-  IMAGE_NAME: {% raw %}${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}{% endraw %}
-  EE_REGISTRY_TLS_VERIFY: {% raw %}${{ inputs.registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || '{% endraw %}{{ ee_registry_tls_verify | lower }}{% raw %}' }}{% endraw %}
+  EE_REGISTRY: {% raw %}${{ inputs.ee_registry || vars.EE_REGISTRY || '{% endraw %}{{ ee_registry }}{% raw %}' }}{% endraw %}
+  EE_IMAGE_NAME: {% raw %}${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}{% endraw %}
+  EE_REGISTRY_TLS_VERIFY: {% raw %}${{ inputs.ee_registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || '{% endraw %}{{ ee_registry_tls_verify | lower }}{% raw %}' }}{% endraw %}
   # EE directory and file name (override via workflow_dispatch inputs or repository Variables)
   EE_DIR: {% raw %}${{ inputs.ee_dir || vars.EE_DIR || '.' }}{% endraw %}
   EE_FILE_NAME: {% raw %}${{ inputs.ee_file_name || vars.EE_FILE_NAME || '{% endraw %}{{ ee_file_name }}{% raw %}' }}{% endraw %}
   # Image build tag (override via workflow_dispatch input or repository Variable)
-  IMAGE_BUILD_TAG: {% raw %}${{ inputs.image_build_tag || vars.IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}{% endraw %}
+  EE_IMAGE_BUILD_TAG: {% raw %}${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}{% endraw %}
   # Base image age thresholds (in days) - annotations only, never blocks the build
   IMAGE_WARN_AGE: 40
   IMAGE_FAIL_AGE: 80
@@ -174,19 +174,19 @@ env:
     name: Validate Image Tag
     runs-on: ubuntu-latest
     steps:
-      - name: Check IMAGE_BUILD_TAG conforms to OCI tag spec
+      - name: Check EE_IMAGE_BUILD_TAG conforms to OCI tag spec
         run: |
-          TAG="${{ env.IMAGE_BUILD_TAG }}"
+          TAG="${{ env.EE_IMAGE_BUILD_TAG }}"
           if [[ -z "$TAG" ]]; then
-            echo "::error::IMAGE_BUILD_TAG is empty"
+            echo "::error::EE_IMAGE_BUILD_TAG is empty"
             exit 1
           fi
           if [[ ${#TAG} -gt 128 ]]; then
-            echo "::error::IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
             exit 1
           fi
           if ! [[ "$TAG" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
-            echo "::error::IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
             echo "::error::Tags must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._-]"
             exit 1
           fi
@@ -310,16 +310,16 @@ env:
 
       - name: Login to container registry
         run: |
-          if [[ "${{ env.REGISTRY }}" == "ghcr.io" ]]; then
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ github.actor }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           else
             echo "${{ secrets.REGISTRY_PASSWORD }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ vars.REGISTRY_USERNAME }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           fi
 
       - name: Login to Red Hat registry (for base images)
@@ -404,7 +404,7 @@ env:
 
 {% raw %}          buildah bud --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
             "${EXTRA_ARGS[@]}" \
-            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+            --tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             --file context/Containerfile \
             context/
           echo "::endgroup::"
@@ -412,9 +412,9 @@ env:
       - name: Test execution environment
         run: |
           echo "::group::Testing EE"
-          podman run --rm "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             ansible --version
-          podman run --rm "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             ansible-galaxy collection list || true
           echo "::endgroup::"
 
@@ -423,8 +423,8 @@ env:
         run: |
           buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
             --digestfile /tmp/digest \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
-            "docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}"
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            "docker://${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
           echo "digest=$(cat /tmp/digest)" >> "$GITHUB_OUTPUT"
 
   # ============================================================================
@@ -438,16 +438,16 @@ env:
     steps:
       - name: Login to container registry
         run: |
-          if [[ "${{ env.REGISTRY }}" == "ghcr.io" ]]; then
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ github.actor }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           else
             echo "${{ secrets.REGISTRY_PASSWORD }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ vars.REGISTRY_USERNAME }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           fi
 
       - name: Tag and push release
@@ -456,24 +456,24 @@ env:
         run: |
           # Pull the image built from this commit (pushed in build job)
           buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}"
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
 
           # Backup previous production tag if it exists
           if buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:prd" 2>/dev/null; then
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" 2>/dev/null; then
             echo "::notice::Backing up previous production image to 'previous' tag"
-            buildah tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:prd" \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
             buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous"
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
           fi
 
           # Tag and push version, latest, and production
           for TAG in "${VERSION}" "latest" "prd"; do
-            buildah tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
             buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
           done
 
           echo "::notice::Released version ${VERSION}"
@@ -522,8 +522,8 @@ env:
           if [[ "${{ needs.build.result }}" == "success" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Image Details" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Registry: \`${{ env.REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Image: \`${{ env.IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Registry: \`${{ env.EE_REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Image: \`${{ env.EE_IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- EE Directory: \`${{ env.EE_DIR }}\`" >> "$GITHUB_STEP_SUMMARY"
           fi
 {%- endraw %}

--- a/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
+++ b/src/ansible_creator/resources/common/ee-ci/.gitlab-ci.yml.j2
@@ -8,8 +8,8 @@
 # - Registry authentication for build and push
 # - Single Podman auth file (REGISTRY_AUTHFILE) for login, build, and push —
 #   avoids push failures on some registries when blob-exists checks need auth
-# - IMAGE_NAME lowercased before tag/push — many OCI registries require
-#   lowercase repository paths (override IMAGE_NAME in CI/CD variables if needed)
+# - EE_IMAGE_NAME lowercased before tag/push — many OCI registries require
+#   lowercase repository paths (override EE_IMAGE_NAME in CI/CD variables if needed)
 #
 # Required CI/CD Variables (Settings > CI/CD > Variables) — use the same names
 # as in the GitHub Actions workflow secrets where applicable:
@@ -55,18 +55,18 @@ default:
   image: quay.io/podman/stable
 
 variables:
-  # REGISTRY / IMAGE_NAME come from EE scaffold (--ee-config registry / image_name).
-  # Build and release jobs normalize IMAGE_NAME to lowercase for OCI tags.
-  REGISTRY: "{{ ee_registry }}"
+  # EE_REGISTRY / EE_IMAGE_NAME come from EE scaffold (--ee-config registry / image_name).
+  # Build and release jobs normalize EE_IMAGE_NAME to lowercase for OCI tags.
+  EE_REGISTRY: "{{ ee_registry }}"
 {%- if ee_image_name %}
-  IMAGE_NAME: "{{ ee_image_name }}"
+  EE_IMAGE_NAME: "{{ ee_image_name }}"
 {%- else %}
-  IMAGE_NAME: "$CI_PROJECT_PATH"
+  EE_IMAGE_NAME: "$CI_PROJECT_PATH"
 {%- endif %}
   EE_DIR: "."
   EE_FILE_NAME: "{{ ee_file_name }}"
   EE_REGISTRY_TLS_VERIFY: "{{ ee_registry_tls_verify | lower }}"
-  IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
+  EE_IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
   IMAGE_WARN_AGE: "40"
   IMAGE_FAIL_AGE: "80"
   SKIP_BASE_IMAGE_VALIDATION: "false"
@@ -223,8 +223,8 @@ build:
       fi
       echo "NOTICE: podman $PODMAN_VERSION — ARG values will not appear in image history"
     - |
-      export IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
-      echo "IMAGE_NAME (OCI-normalized): ${IMAGE_NAME}"
+      export EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+      echo "EE_IMAGE_NAME (OCI-normalized): ${EE_IMAGE_NAME}"
   script:
     - |
       REGISTRY_AUTHFILE="${CI_PROJECT_DIR}/.containers-auth.json"
@@ -234,7 +234,7 @@ build:
         podman login --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         -u "${REGISTRY_USERNAME:-$CI_REGISTRY_USER}" \
-        --password-stdin "$REGISTRY"
+        --password-stdin "$EE_REGISTRY"
 
     - |
       if [ -n "$REDHAT_REGISTRY_USERNAME" ]; then
@@ -292,16 +292,16 @@ build:
       # shellcheck disable=SC2086
       podman build --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" $EXTRA_ARGS \
-        --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+        --tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         --file context/Containerfile \
         context/
       echo -e "\e[0Ksection_end:$(date +%s):build_image\r\e[0K"
 
     - |
       echo -e "\e[0Ksection_start:$(date +%s):test_ee\r\e[0KTesting EE"
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+      podman run --rm "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         ansible --version
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+      podman run --rm "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         ansible-galaxy collection list || true
       echo -e "\e[0Ksection_end:$(date +%s):test_ee\r\e[0K"
 
@@ -309,7 +309,7 @@ build:
       podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         --digestfile /tmp/digest \
-        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}"
       echo "IMAGE_DIGEST=$(cat /tmp/digest)" >> build.env
   artifacts:
     reports:
@@ -327,7 +327,7 @@ release:
   rules:
     - if: $CI_COMMIT_TAG
   script:
-    - export IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+    - export EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
     - |
       REGISTRY_AUTHFILE="${CI_PROJECT_DIR}/.containers-auth.json"
       export REGISTRY_AUTHFILE
@@ -336,31 +336,31 @@ release:
         podman login --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         -u "${REGISTRY_USERNAME:-$CI_REGISTRY_USER}" \
-        --password-stdin "$REGISTRY"
+        --password-stdin "$EE_REGISTRY"
 
     - |
       VERSION="$CI_COMMIT_TAG"
       podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}"
 
       if podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:prd" 2>/dev/null; then
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:prd" 2>/dev/null; then
         echo "Backing up previous production image to 'previous' tag"
-        podman tag "${REGISTRY}/${IMAGE_NAME}:prd" \
-          "${REGISTRY}/${IMAGE_NAME}:previous"
+        podman tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:prd" \
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:previous"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
-          "${REGISTRY}/${IMAGE_NAME}:previous"
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:previous"
       fi
 
       for TAG in "$VERSION" "latest" "prd"; do
-        podman tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
-          "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+        podman tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:${TAG}"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
-          "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:${TAG}"
       done
 
       echo "Released version ${VERSION}"
@@ -383,7 +383,7 @@ summary:
       optional: true
   script:
     - |
-      IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+      EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
       {
         echo "## Execution Environment Build Summary"
         echo ""
@@ -407,9 +407,9 @@ summary:
         fi
 
         echo "### Image Details"
-        echo "- Registry: \`${REGISTRY}\`"
-        echo "- Image: \`${IMAGE_NAME}\`"
-        echo "- Tag: \`${IMAGE_BUILD_TAG}\`"
+        echo "- Registry: \`${EE_REGISTRY}\`"
+        echo "- Image: \`${EE_IMAGE_NAME}\`"
+        echo "- Tag: \`${EE_IMAGE_BUILD_TAG}\`"
         echo "- EE Directory: \`${EE_DIR}\`"
         if [ -n "$IMAGE_DIGEST" ]; then
           echo "- Digest: \`${IMAGE_DIGEST}\`"

--- a/tests/fixtures/common/ee-ci/.github/workflows/ee-build.yml
+++ b/tests/fixtures/common/ee-ci/.github/workflows/ee-build.yml
@@ -51,12 +51,12 @@ on:
         required: false
         default: ""
         type: string
-      registry_tls_verify:
+      ee_registry_tls_verify:
         description: "Verify TLS certificates for container registries (true/false)"
         required: false
         default: "true"
         type: string
-      image_build_tag:
+      ee_image_build_tag:
         description: "Custom image tag for the build (defaults to build-<commit SHA>)"
         required: false
         type: string
@@ -72,23 +72,23 @@ permissions:
   packages: write
 
 # Prevent concurrent builds from racing to push the same image tag.
-# A static custom tag (e.g. vars.IMAGE_BUILD_TAG=test) dispatched on
+# A static custom tag (e.g. vars.EE_IMAGE_BUILD_TAG=test) dispatched on
 # different refs would otherwise land in separate groups yet push to
 # the same registry tag. Including the resolved tag serialises them.
 concurrency:
-  group: ee-build-${{ github.ref }}-${{ inputs.image_build_tag || vars.IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  group: ee-build-${{ github.ref }}-${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
   cancel-in-progress: false
 
 env:
   # Container registry configuration (override via repository Variables)
-  REGISTRY: ${{ inputs.ee_registry || vars.EE_REGISTRY || 'ghcr.io' }}
-  IMAGE_NAME: ${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}
-  EE_REGISTRY_TLS_VERIFY: ${{ inputs.registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || 'true' }}
+  EE_REGISTRY: ${{ inputs.ee_registry || vars.EE_REGISTRY || 'ghcr.io' }}
+  EE_IMAGE_NAME: ${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}
+  EE_REGISTRY_TLS_VERIFY: ${{ inputs.ee_registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || 'true' }}
   # EE directory and file name (override via workflow_dispatch inputs or repository Variables)
   EE_DIR: ${{ inputs.ee_dir || vars.EE_DIR || '.' }}
   EE_FILE_NAME: ${{ inputs.ee_file_name || vars.EE_FILE_NAME || 'execution-environment.yml' }}
   # Image build tag (override via workflow_dispatch input or repository Variable)
-  IMAGE_BUILD_TAG: ${{ inputs.image_build_tag || vars.IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  EE_IMAGE_BUILD_TAG: ${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
   # Base image age thresholds (in days) - annotations only, never blocks the build
   IMAGE_WARN_AGE: 40
   IMAGE_FAIL_AGE: 80
@@ -121,19 +121,19 @@ jobs:
     name: Validate Image Tag
     runs-on: ubuntu-latest
     steps:
-      - name: Check IMAGE_BUILD_TAG conforms to OCI tag spec
+      - name: Check EE_IMAGE_BUILD_TAG conforms to OCI tag spec
         run: |
-          TAG="${{ env.IMAGE_BUILD_TAG }}"
+          TAG="${{ env.EE_IMAGE_BUILD_TAG }}"
           if [[ -z "$TAG" ]]; then
-            echo "::error::IMAGE_BUILD_TAG is empty"
+            echo "::error::EE_IMAGE_BUILD_TAG is empty"
             exit 1
           fi
           if [[ ${#TAG} -gt 128 ]]; then
-            echo "::error::IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
             exit 1
           fi
           if ! [[ "$TAG" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
-            echo "::error::IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
             echo "::error::Tags must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._-]"
             exit 1
           fi
@@ -257,16 +257,16 @@ jobs:
 
       - name: Login to container registry
         run: |
-          if [[ "${{ env.REGISTRY }}" == "ghcr.io" ]]; then
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ github.actor }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           else
             echo "${{ secrets.REGISTRY_PASSWORD }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ vars.REGISTRY_USERNAME }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           fi
 
       - name: Login to Red Hat registry (for base images)
@@ -314,7 +314,7 @@ jobs:
 
           buildah bud --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
             "${EXTRA_ARGS[@]}" \
-            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+            --tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             --file context/Containerfile \
             context/
           echo "::endgroup::"
@@ -322,9 +322,9 @@ jobs:
       - name: Test execution environment
         run: |
           echo "::group::Testing EE"
-          podman run --rm "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             ansible --version
-          podman run --rm "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             ansible-galaxy collection list || true
           echo "::endgroup::"
 
@@ -333,8 +333,8 @@ jobs:
         run: |
           buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
             --digestfile /tmp/digest \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
-            "docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}"
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            "docker://${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
           echo "digest=$(cat /tmp/digest)" >> "$GITHUB_OUTPUT"
 
   # ============================================================================
@@ -348,16 +348,16 @@ jobs:
     steps:
       - name: Login to container registry
         run: |
-          if [[ "${{ env.REGISTRY }}" == "ghcr.io" ]]; then
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ github.actor }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           else
             echo "${{ secrets.REGISTRY_PASSWORD }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ vars.REGISTRY_USERNAME }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           fi
 
       - name: Tag and push release
@@ -366,24 +366,24 @@ jobs:
         run: |
           # Pull the image built from this commit (pushed in build job)
           buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}"
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
 
           # Backup previous production tag if it exists
           if buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:prd" 2>/dev/null; then
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" 2>/dev/null; then
             echo "::notice::Backing up previous production image to 'previous' tag"
-            buildah tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:prd" \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
             buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous"
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
           fi
 
           # Tag and push version, latest, and production
           for TAG in "${VERSION}" "latest" "prd"; do
-            buildah tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
             buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
           done
 
           echo "::notice::Released version ${VERSION}"
@@ -432,7 +432,7 @@ jobs:
           if [[ "${{ needs.build.result }}" == "success" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Image Details" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Registry: \`${{ env.REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Image: \`${{ env.IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Registry: \`${{ env.EE_REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Image: \`${{ env.EE_IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- EE Directory: \`${{ env.EE_DIR }}\`" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/tests/fixtures/common/ee-ci/.gitlab-ci.yml
+++ b/tests/fixtures/common/ee-ci/.gitlab-ci.yml
@@ -8,8 +8,8 @@
 # - Registry authentication for build and push
 # - Single Podman auth file (REGISTRY_AUTHFILE) for login, build, and push —
 #   avoids push failures on some registries when blob-exists checks need auth
-# - IMAGE_NAME lowercased before tag/push — many OCI registries require
-#   lowercase repository paths (override IMAGE_NAME in CI/CD variables if needed)
+# - EE_IMAGE_NAME lowercased before tag/push — many OCI registries require
+#   lowercase repository paths (override EE_IMAGE_NAME in CI/CD variables if needed)
 #
 # Required CI/CD Variables (Settings > CI/CD > Variables) — use the same names
 # as in the GitHub Actions workflow secrets where applicable:
@@ -49,14 +49,14 @@ default:
   image: quay.io/podman/stable
 
 variables:
-  # REGISTRY / IMAGE_NAME come from EE scaffold (--ee-config registry / image_name).
-  # Build and release jobs normalize IMAGE_NAME to lowercase for OCI tags.
-  REGISTRY: "ghcr.io"
-  IMAGE_NAME: "$CI_PROJECT_PATH"
+  # EE_REGISTRY / EE_IMAGE_NAME come from EE scaffold (--ee-config registry / image_name).
+  # Build and release jobs normalize EE_IMAGE_NAME to lowercase for OCI tags.
+  EE_REGISTRY: "ghcr.io"
+  EE_IMAGE_NAME: "$CI_PROJECT_PATH"
   EE_DIR: "."
   EE_FILE_NAME: "execution-environment.yml"
   EE_REGISTRY_TLS_VERIFY: "true"
-  IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
+  EE_IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
   IMAGE_WARN_AGE: "40"
   IMAGE_FAIL_AGE: "80"
   SKIP_BASE_IMAGE_VALIDATION: "false"
@@ -191,8 +191,8 @@ build:
       fi
       echo "NOTICE: podman $PODMAN_VERSION — ARG values will not appear in image history"
     - |
-      export IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
-      echo "IMAGE_NAME (OCI-normalized): ${IMAGE_NAME}"
+      export EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+      echo "EE_IMAGE_NAME (OCI-normalized): ${EE_IMAGE_NAME}"
   script:
     - |
       REGISTRY_AUTHFILE="${CI_PROJECT_DIR}/.containers-auth.json"
@@ -202,7 +202,7 @@ build:
         podman login --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         -u "${REGISTRY_USERNAME:-$CI_REGISTRY_USER}" \
-        --password-stdin "$REGISTRY"
+        --password-stdin "$EE_REGISTRY"
 
     - |
       if [ -n "$REDHAT_REGISTRY_USERNAME" ]; then
@@ -231,16 +231,16 @@ build:
       # shellcheck disable=SC2086
       podman build --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" $EXTRA_ARGS \
-        --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+        --tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         --file context/Containerfile \
         context/
       echo -e "\e[0Ksection_end:$(date +%s):build_image\r\e[0K"
 
     - |
       echo -e "\e[0Ksection_start:$(date +%s):test_ee\r\e[0KTesting EE"
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+      podman run --rm "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         ansible --version
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+      podman run --rm "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         ansible-galaxy collection list || true
       echo -e "\e[0Ksection_end:$(date +%s):test_ee\r\e[0K"
 
@@ -248,7 +248,7 @@ build:
       podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         --digestfile /tmp/digest \
-        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}"
       echo "IMAGE_DIGEST=$(cat /tmp/digest)" >> build.env
   artifacts:
     reports:
@@ -266,7 +266,7 @@ release:
   rules:
     - if: $CI_COMMIT_TAG
   script:
-    - export IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+    - export EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
     - |
       REGISTRY_AUTHFILE="${CI_PROJECT_DIR}/.containers-auth.json"
       export REGISTRY_AUTHFILE
@@ -275,31 +275,31 @@ release:
         podman login --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         -u "${REGISTRY_USERNAME:-$CI_REGISTRY_USER}" \
-        --password-stdin "$REGISTRY"
+        --password-stdin "$EE_REGISTRY"
 
     - |
       VERSION="$CI_COMMIT_TAG"
       podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}"
 
       if podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:prd" 2>/dev/null; then
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:prd" 2>/dev/null; then
         echo "Backing up previous production image to 'previous' tag"
-        podman tag "${REGISTRY}/${IMAGE_NAME}:prd" \
-          "${REGISTRY}/${IMAGE_NAME}:previous"
+        podman tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:prd" \
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:previous"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
-          "${REGISTRY}/${IMAGE_NAME}:previous"
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:previous"
       fi
 
       for TAG in "$VERSION" "latest" "prd"; do
-        podman tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
-          "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+        podman tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:${TAG}"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
-          "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:${TAG}"
       done
 
       echo "Released version ${VERSION}"
@@ -322,7 +322,7 @@ summary:
       optional: true
   script:
     - |
-      IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+      EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
       {
         echo "## Execution Environment Build Summary"
         echo ""
@@ -346,9 +346,9 @@ summary:
         fi
 
         echo "### Image Details"
-        echo "- Registry: \`${REGISTRY}\`"
-        echo "- Image: \`${IMAGE_NAME}\`"
-        echo "- Tag: \`${IMAGE_BUILD_TAG}\`"
+        echo "- Registry: \`${EE_REGISTRY}\`"
+        echo "- Image: \`${EE_IMAGE_NAME}\`"
+        echo "- Tag: \`${EE_IMAGE_BUILD_TAG}\`"
         echo "- EE Directory: \`${EE_DIR}\`"
         if [ -n "$IMAGE_DIGEST" ]; then
           echo "- Digest: \`${IMAGE_DIGEST}\`"

--- a/tests/fixtures/project/ee_project/.github/workflows/ee-build.yml
+++ b/tests/fixtures/project/ee_project/.github/workflows/ee-build.yml
@@ -51,12 +51,12 @@ on:
         required: false
         default: ""
         type: string
-      registry_tls_verify:
+      ee_registry_tls_verify:
         description: "Verify TLS certificates for container registries (true/false)"
         required: false
         default: "true"
         type: string
-      image_build_tag:
+      ee_image_build_tag:
         description: "Custom image tag for the build (defaults to build-<commit SHA>)"
         required: false
         type: string
@@ -72,23 +72,23 @@ permissions:
   packages: write
 
 # Prevent concurrent builds from racing to push the same image tag.
-# A static custom tag (e.g. vars.IMAGE_BUILD_TAG=test) dispatched on
+# A static custom tag (e.g. vars.EE_IMAGE_BUILD_TAG=test) dispatched on
 # different refs would otherwise land in separate groups yet push to
 # the same registry tag. Including the resolved tag serialises them.
 concurrency:
-  group: ee-build-${{ github.ref }}-${{ inputs.image_build_tag || vars.IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  group: ee-build-${{ github.ref }}-${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
   cancel-in-progress: false
 
 env:
   # Container registry configuration (override via repository Variables)
-  REGISTRY: ${{ inputs.ee_registry || vars.EE_REGISTRY || 'ghcr.io' }}
-  IMAGE_NAME: ${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}
-  EE_REGISTRY_TLS_VERIFY: ${{ inputs.registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || 'true' }}
+  EE_REGISTRY: ${{ inputs.ee_registry || vars.EE_REGISTRY || 'ghcr.io' }}
+  EE_IMAGE_NAME: ${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}
+  EE_REGISTRY_TLS_VERIFY: ${{ inputs.ee_registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || 'true' }}
   # EE directory and file name (override via workflow_dispatch inputs or repository Variables)
   EE_DIR: ${{ inputs.ee_dir || vars.EE_DIR || '.' }}
   EE_FILE_NAME: ${{ inputs.ee_file_name || vars.EE_FILE_NAME || 'execution-environment.yml' }}
   # Image build tag (override via workflow_dispatch input or repository Variable)
-  IMAGE_BUILD_TAG: ${{ inputs.image_build_tag || vars.IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  EE_IMAGE_BUILD_TAG: ${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
   # Base image age thresholds (in days) - annotations only, never blocks the build
   IMAGE_WARN_AGE: 40
   IMAGE_FAIL_AGE: 80
@@ -121,19 +121,19 @@ jobs:
     name: Validate Image Tag
     runs-on: ubuntu-latest
     steps:
-      - name: Check IMAGE_BUILD_TAG conforms to OCI tag spec
+      - name: Check EE_IMAGE_BUILD_TAG conforms to OCI tag spec
         run: |
-          TAG="${{ env.IMAGE_BUILD_TAG }}"
+          TAG="${{ env.EE_IMAGE_BUILD_TAG }}"
           if [[ -z "$TAG" ]]; then
-            echo "::error::IMAGE_BUILD_TAG is empty"
+            echo "::error::EE_IMAGE_BUILD_TAG is empty"
             exit 1
           fi
           if [[ ${#TAG} -gt 128 ]]; then
-            echo "::error::IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
             exit 1
           fi
           if ! [[ "$TAG" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
-            echo "::error::IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
             echo "::error::Tags must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._-]"
             exit 1
           fi
@@ -257,16 +257,16 @@ jobs:
 
       - name: Login to container registry
         run: |
-          if [[ "${{ env.REGISTRY }}" == "ghcr.io" ]]; then
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ github.actor }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           else
             echo "${{ secrets.REGISTRY_PASSWORD }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ vars.REGISTRY_USERNAME }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           fi
 
       - name: Login to Red Hat registry (for base images)
@@ -314,7 +314,7 @@ jobs:
 
           buildah bud --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
             "${EXTRA_ARGS[@]}" \
-            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+            --tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             --file context/Containerfile \
             context/
           echo "::endgroup::"
@@ -322,9 +322,9 @@ jobs:
       - name: Test execution environment
         run: |
           echo "::group::Testing EE"
-          podman run --rm "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             ansible --version
-          podman run --rm "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
             ansible-galaxy collection list || true
           echo "::endgroup::"
 
@@ -333,8 +333,8 @@ jobs:
         run: |
           buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
             --digestfile /tmp/digest \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
-            "docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}"
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            "docker://${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
           echo "digest=$(cat /tmp/digest)" >> "$GITHUB_OUTPUT"
 
   # ============================================================================
@@ -348,16 +348,16 @@ jobs:
     steps:
       - name: Login to container registry
         run: |
-          if [[ "${{ env.REGISTRY }}" == "ghcr.io" ]]; then
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ github.actor }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           else
             echo "${{ secrets.REGISTRY_PASSWORD }}" | \
               buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
               -u "${{ vars.REGISTRY_USERNAME }}" \
-              --password-stdin "${{ env.REGISTRY }}"
+              --password-stdin "${{ env.EE_REGISTRY }}"
           fi
 
       - name: Tag and push release
@@ -366,24 +366,24 @@ jobs:
         run: |
           # Pull the image built from this commit (pushed in build job)
           buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}"
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
 
           # Backup previous production tag if it exists
           if buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:prd" 2>/dev/null; then
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" 2>/dev/null; then
             echo "::notice::Backing up previous production image to 'previous' tag"
-            buildah tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:prd" \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
             buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous"
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
           fi
 
           # Tag and push version, latest, and production
           for TAG in "${VERSION}" "latest" "prd"; do
-            buildah tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_BUILD_TAG }}" \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
             buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
-              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
           done
 
           echo "::notice::Released version ${VERSION}"
@@ -432,7 +432,7 @@ jobs:
           if [[ "${{ needs.build.result }}" == "success" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Image Details" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Registry: \`${{ env.REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Image: \`${{ env.IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Registry: \`${{ env.EE_REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Image: \`${{ env.EE_IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- EE Directory: \`${{ env.EE_DIR }}\`" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/tests/fixtures/project/ee_project_gitlab/.gitlab-ci.yml
+++ b/tests/fixtures/project/ee_project_gitlab/.gitlab-ci.yml
@@ -8,8 +8,8 @@
 # - Registry authentication for build and push
 # - Single Podman auth file (REGISTRY_AUTHFILE) for login, build, and push —
 #   avoids push failures on some registries when blob-exists checks need auth
-# - IMAGE_NAME lowercased before tag/push — many OCI registries require
-#   lowercase repository paths (override IMAGE_NAME in CI/CD variables if needed)
+# - EE_IMAGE_NAME lowercased before tag/push — many OCI registries require
+#   lowercase repository paths (override EE_IMAGE_NAME in CI/CD variables if needed)
 #
 # Required CI/CD Variables (Settings > CI/CD > Variables) — use the same names
 # as in the GitHub Actions workflow secrets where applicable:
@@ -49,14 +49,14 @@ default:
   image: quay.io/podman/stable
 
 variables:
-  # REGISTRY / IMAGE_NAME come from EE scaffold (--ee-config registry / image_name).
-  # Build and release jobs normalize IMAGE_NAME to lowercase for OCI tags.
-  REGISTRY: "ghcr.io"
-  IMAGE_NAME: "$CI_PROJECT_PATH"
+  # EE_REGISTRY / EE_IMAGE_NAME come from EE scaffold (--ee-config registry / image_name).
+  # Build and release jobs normalize EE_IMAGE_NAME to lowercase for OCI tags.
+  EE_REGISTRY: "ghcr.io"
+  EE_IMAGE_NAME: "$CI_PROJECT_PATH"
   EE_DIR: "."
   EE_FILE_NAME: "execution-environment.yml"
   EE_REGISTRY_TLS_VERIFY: "true"
-  IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
+  EE_IMAGE_BUILD_TAG: "build-${CI_COMMIT_SHA}"
   IMAGE_WARN_AGE: "40"
   IMAGE_FAIL_AGE: "80"
   SKIP_BASE_IMAGE_VALIDATION: "false"
@@ -191,8 +191,8 @@ build:
       fi
       echo "NOTICE: podman $PODMAN_VERSION — ARG values will not appear in image history"
     - |
-      export IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
-      echo "IMAGE_NAME (OCI-normalized): ${IMAGE_NAME}"
+      export EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+      echo "EE_IMAGE_NAME (OCI-normalized): ${EE_IMAGE_NAME}"
   script:
     - |
       REGISTRY_AUTHFILE="${CI_PROJECT_DIR}/.containers-auth.json"
@@ -202,7 +202,7 @@ build:
         podman login --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         -u "${REGISTRY_USERNAME:-$CI_REGISTRY_USER}" \
-        --password-stdin "$REGISTRY"
+        --password-stdin "$EE_REGISTRY"
 
     - |
       if [ -n "$REDHAT_REGISTRY_USERNAME" ]; then
@@ -231,16 +231,16 @@ build:
       # shellcheck disable=SC2086
       podman build --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" $EXTRA_ARGS \
-        --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+        --tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         --file context/Containerfile \
         context/
       echo -e "\e[0Ksection_end:$(date +%s):build_image\r\e[0K"
 
     - |
       echo -e "\e[0Ksection_start:$(date +%s):test_ee\r\e[0KTesting EE"
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+      podman run --rm "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         ansible --version
-      podman run --rm "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
+      podman run --rm "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
         ansible-galaxy collection list || true
       echo -e "\e[0Ksection_end:$(date +%s):test_ee\r\e[0K"
 
@@ -248,7 +248,7 @@ build:
       podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         --digestfile /tmp/digest \
-        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}"
       echo "IMAGE_DIGEST=$(cat /tmp/digest)" >> build.env
   artifacts:
     reports:
@@ -266,7 +266,7 @@ release:
   rules:
     - if: $CI_COMMIT_TAG
   script:
-    - export IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+    - export EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
     - |
       REGISTRY_AUTHFILE="${CI_PROJECT_DIR}/.containers-auth.json"
       export REGISTRY_AUTHFILE
@@ -275,31 +275,31 @@ release:
         podman login --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
         -u "${REGISTRY_USERNAME:-$CI_REGISTRY_USER}" \
-        --password-stdin "$REGISTRY"
+        --password-stdin "$EE_REGISTRY"
 
     - |
       VERSION="$CI_COMMIT_TAG"
       podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}"
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}"
 
       if podman pull --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
         --authfile "$REGISTRY_AUTHFILE" \
-        "${REGISTRY}/${IMAGE_NAME}:prd" 2>/dev/null; then
+        "${EE_REGISTRY}/${EE_IMAGE_NAME}:prd" 2>/dev/null; then
         echo "Backing up previous production image to 'previous' tag"
-        podman tag "${REGISTRY}/${IMAGE_NAME}:prd" \
-          "${REGISTRY}/${IMAGE_NAME}:previous"
+        podman tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:prd" \
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:previous"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
-          "${REGISTRY}/${IMAGE_NAME}:previous"
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:previous"
       fi
 
       for TAG in "$VERSION" "latest" "prd"; do
-        podman tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_BUILD_TAG}" \
-          "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+        podman tag "${EE_REGISTRY}/${EE_IMAGE_NAME}:${EE_IMAGE_BUILD_TAG}" \
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:${TAG}"
         podman push --tls-verify="$EE_REGISTRY_TLS_VERIFY" \
           --authfile "$REGISTRY_AUTHFILE" \
-          "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+          "${EE_REGISTRY}/${EE_IMAGE_NAME}:${TAG}"
       done
 
       echo "Released version ${VERSION}"
@@ -322,7 +322,7 @@ summary:
       optional: true
   script:
     - |
-      IMAGE_NAME="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+      EE_IMAGE_NAME="$(printf '%s' "$EE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
       {
         echo "## Execution Environment Build Summary"
         echo ""
@@ -346,9 +346,9 @@ summary:
         fi
 
         echo "### Image Details"
-        echo "- Registry: \`${REGISTRY}\`"
-        echo "- Image: \`${IMAGE_NAME}\`"
-        echo "- Tag: \`${IMAGE_BUILD_TAG}\`"
+        echo "- Registry: \`${EE_REGISTRY}\`"
+        echo "- Image: \`${EE_IMAGE_NAME}\`"
+        echo "- Tag: \`${EE_IMAGE_BUILD_TAG}\`"
         echo "- EE Directory: \`${EE_DIR}\`"
         if [ -n "$IMAGE_DIGEST" ]; then
           echo "- Digest: \`${IMAGE_DIGEST}\`"


### PR DESCRIPTION
## Summary

- Rename CI variables in both GitHub and GitLab templates to use a consistent `EE_` prefix for all overridable build parameters:
  - `REGISTRY` → `EE_REGISTRY`
  - `IMAGE_NAME` → `EE_IMAGE_NAME`
  - `IMAGE_BUILD_TAG` → `EE_IMAGE_BUILD_TAG`
  - `image_build_tag` → `ee_image_build_tag` (GitHub input)
  - `registry_tls_verify` → `ee_registry_tls_verify` (GitHub input)
- Fix lowercasing in GitLab CI: the OCI normalization was writing to a dead local `IMAGE_NAME` variable instead of updating `EE_IMAGE_NAME` in place
- Update `ee_scaffolding.md` doc reference
- Update all test fixtures

## Why

Overridable CI variables used inconsistent naming — some had the `EE_` prefix (`EE_DIR`, `EE_FILE_NAME`, `EE_REGISTRY_TLS_VERIFY`) while others did not (`REGISTRY`, `IMAGE_NAME`, `IMAGE_BUILD_TAG`). This made it unclear which variables belonged to the EE build configuration and caused mismatches when API consumers passed variables with the `EE_` prefix.

## Test plan

- [x] `test_run_success_add_ee_ci` passes
- [x] `test_run_success_add_ee_ci_gitlab` passes