### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -9,6 +9,8 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
+permissions:
+  contents: read
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,8 @@ on:
       - "releases/**"
       - "stable/**"
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/push.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ name: release
 on:
   release:
     types: [published]
+permissions:
+  contents: read
 jobs:
   release:
     environment: release

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,6 +15,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_call:
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Resolve CodeQL code-scanning alerts for missing workflow permissions by adding top-level `permissions: contents: read` to all workflows, following the principle of least privilege.