### PR TITLE
fix(ci): remove overly restrictive top-level permissions from workflows

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -9,8 +9,6 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
-permissions:
-  contents: read
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,8 +8,6 @@ on:
       - "releases/**"
       - "stable/**"
   workflow_dispatch:
-permissions:
-  contents: read
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/push.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ name: release
 on:
   release:
     types: [published]
-permissions:
-  contents: read
 jobs:
   release:
     environment: release

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,8 +15,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_call:
-permissions:
-  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Removes the `permissions: contents: read` top-level blocks added by #617 from `tox.yml`, `ack.yml`, `push.yml`, and `release.yml`
- These blocks caused `startup_failure` on tox, ack, and push workflows for 4+ days because the reusable workflows in `team-devtools` require broader permissions (`checks`, `id-token`, `packages`, `pull-requests`) that the caller was blocking
- The reusable workflows already manage their own permissions at the job level — callers should not restrict them

## Root cause

GitHub Actions enforces that a reusable workflow's `GITHUB_TOKEN` can only have permissions equal to or **more restrictive** than what the caller grants. PR #617 set `permissions: contents: read` at the top level, which implicitly set all other permissions to `none`. The reusable `tox.yml` in `team-devtools` needs `packages: write`, `pull-requests: write`, `id-token: write`, and `checks: read` — all of which were blocked.

## Test plan

- [ ] tox workflow passes on this PR branch
- [ ] ack workflow passes on this PR branch
- [ ] After merge: verify scheduled tox run succeeds on main
- [ ] After merge: verify push workflow succeeds on main