### PR TITLE
Add migrate molecule for ansible-test integration targets

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,6 +13,7 @@ This document provides comprehensive guidelines for AI agents working with Ansib
   - [Starting Approach](#starting-approach)
   - [Testing and Validation](#testing-and-validation)
     - [Testing Strategies](#testing-strategies)
+    - [Migrating ansible-test integration targets to Molecule](#migrating-ansible-test-integration-targets-to-molecule)
     - [Smoke Testing](#smoke-testing)
 - [Coding Standards](#coding-standards)
   - [Formatting](#formatting)
@@ -127,9 +128,39 @@ A playbook project orchestrates landscapes and types via one or more playbooks, 
 - [ ] Increase reliability and reduce costs through testing
 - [ ] Test playbooks in non-production environments first
 - [ ] Validate changes before deploying to production
-- [ ] Use `molecule` or similar tools for role testing
+    - [ ] Use `molecule` or similar tools for role testing
 - [ ] Test against multiple platforms when supporting diverse environments
 - [ ] Automate testing as part of CI/CD pipeline
+
+#### Migrating ansible-test integration targets to Molecule
+
+Use `ansible-creator migrate molecule` to move role-shaped
+`tests/integration/targets/<name>/` trees into real on-disk scenarios:
+
+```text
+ansible-creator migrate molecule <target> [--path PATH]
+ansible-creator migrate molecule --all [--path PATH]
+```
+
+Default behavior **moves** the target into:
+
+```text
+extensions/molecule/
+  config.yml                # ansible-native shared config
+  inventory.yml             # localhost / ansible_connection: local
+  <target>/
+    molecule.yml            # thin; overrides only if needed
+    converge.yml            # include_role name: content
+    roles/content/          # former target role tree
+```
+
+After migration:
+
+1. Follow `extensions/molecule/MIGRATE_NEXT_STEPS.md`
+2. Use `.agents/skills/molecule-migrate-finalize/SKILL.md` for agent-assisted finalization
+3. Review shared inventory, drop obsolete `aliases`, run `molecule test -s <target>`, update CI
+
+Use `--keep-targets` only when you must retain ansible-test paths temporarily (hybrid). Prefer completing the move rather than leaving dual trees forever.
 
 #### Smoke Testing
 

--- a/src/ansible_creator/api.py
+++ b/src/ansible_creator/api.py
@@ -185,9 +185,9 @@ class V1:
         args = vars(namespace)
         output, messages = self._build_output(args, kwargs)
 
-        # Determine the output path -- only init/add need a workspace dir
+        # Determine the output path -- init/add/migrate need a workspace dir
         subcommand = command_path[0]
-        needs_workspace = subcommand in ("init", "add")
+        needs_workspace = subcommand in ("init", "add", "migrate")
         output_dir: Path | None = None
 
         if needs_workspace:
@@ -443,6 +443,6 @@ class V1:
         """
         if subcommand == "init" and "init_path" in kwargs:
             return str(kwargs["init_path"])
-        if subcommand == "add" and "path" in kwargs:
+        if subcommand in ("add", "migrate") and "path" in kwargs:
             return str(kwargs["path"])
         return None

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -47,6 +47,7 @@ class Parser:
         self.add_parser: argparse.ArgumentParser | None = None
         self.add_resource_parser: argparse.ArgumentParser | None = None
         self.add_plugin_parser: argparse.ArgumentParser | None = None
+        self.migrate_parser: argparse.ArgumentParser | None = None
         self.exit_code: int = 0
 
     def build_parser(self) -> CustomArgumentParser:
@@ -71,6 +72,7 @@ class Parser:
         )
         self._add(subparser=subparser)  # type: ignore[arg-type]
         self._init(subparser=subparser)  # type: ignore[arg-type]
+        self._migrate(subparser=subparser)  # type: ignore[arg-type]
         self._schema(subparser=subparser)  # type: ignore[arg-type]
         return parser
 
@@ -149,6 +151,21 @@ class Parser:
                     prefix=Level.ERROR,
                     message="Missing required argument 'plugin-type'.\n"
                     "Choose from: action, filter, lookup, module, test",
+                )
+            )
+            self.exit_code = os.EX_USAGE
+
+        # Show help for 'ansible-creator migrate' without arguments
+        if (
+            self.args.subcommand == "migrate"
+            and getattr(self.args, "migrate_type", None) is None
+            and self.migrate_parser
+        ):
+            self.migrate_parser.print_help(sys.stderr)
+            self.pending_logs.append(
+                Msg(
+                    prefix=Level.ERROR,
+                    message="Missing required argument 'migrate-type'.\nChoose from: molecule",
                 )
             )
             self.exit_code = os.EX_USAGE
@@ -644,6 +661,77 @@ class Parser:
         self._init_collection(subparser=subparser)
         self._init_playbook(subparser=subparser)
         self._init_ee_project(subparser=subparser)
+
+    def _migrate(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Migrate existing Ansible content into newer layouts.
+
+        Args:
+            subparser: The subparser to add migrate to
+        """
+        parser = subparser.add_parser(
+            "migrate",
+            help="Migrate existing Ansible content into newer layouts.",
+        )
+        self.migrate_parser = parser
+        migrate_sub = parser.add_subparsers(
+            dest="migrate_type",
+            metavar="migrate-type",
+            required=False,
+        )
+        self._migrate_molecule(subparser=migrate_sub)
+
+    def _migrate_molecule(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Migrate ansible-test integration targets into Molecule scenarios.
+
+        Args:
+            subparser: The subparser to add molecule migrate to
+        """
+        parser = subparser.add_parser(
+            "molecule",
+            help=(
+                "Move ansible-test integration targets under "
+                "extensions/molecule/ as real Molecule scenarios."
+            ),
+        )
+        parser.add_argument(
+            "target_name",
+            nargs="?",
+            default="",
+            help=(
+                "Integration target name under tests/integration/targets/. "
+                "Omit when using --all."
+            ),
+        )
+        parser.add_argument(
+            "--path",
+            "-p",
+            default="./",
+            dest="path",
+            metavar="path",
+            help=(
+                "The path to the Ansible collection. The default is the "
+                "current working directory."
+            ),
+        )
+        parser.add_argument(
+            "--all",
+            dest="migrate_all",
+            default=False,
+            action="store_true",
+            help="Migrate all role-shaped integration targets.",
+        )
+        parser.add_argument(
+            "--keep-targets",
+            dest="keep_targets",
+            default=False,
+            action="store_true",
+            help=(
+                "Copy targets into scenarios instead of moving them "
+                "(keeps ansible-test paths for hybrid use)."
+            ),
+        )
+        self._add_overwrite(parser)
+        self._add_args_common(parser)
 
     def _schema(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
         """Output CLI schema as JSON.

--- a/src/ansible_creator/bundles.py
+++ b/src/ansible_creator/bundles.py
@@ -18,6 +18,7 @@ _INIT_EXCLUDED_BUNDLES: frozenset[str] = frozenset(
         "ee-ci",
         "execution-environment",
         "play-argspec",
+        "molecule_migrate",
     },
 )
 

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -54,6 +54,10 @@ class Config:
         scm_provider: SCM provider for EE CI scaffolding (github or gitlab).
         include: Resource bundles to include during init (default: all).
         exclude: Resource bundles to exclude during init.
+        migrate_type: The migrate destination type (e.g. molecule).
+        target_name: Integration target name to migrate (omit with --all).
+        migrate_all: Migrate all role-shaped integration targets.
+        keep_targets: Copy targets into scenarios instead of moving them.
     """
 
     creator_version: str
@@ -88,6 +92,10 @@ class Config:
     scm_provider: str = "github"
     include: Sequence[str] = field(default_factory=lambda: ["all"])
     exclude: Sequence[str] = field(default_factory=list)
+    migrate_type: str = ""
+    target_name: str = ""
+    migrate_all: bool = False
+    keep_targets: bool = False
 
     def __post_init__(self) -> None:
         """Post process config values."""

--- a/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
@@ -1,0 +1,28 @@
+---
+# Molecule migration next steps
+
+ansible-creator migrated these integration targets into Molecule scenarios:
+
+{{ target_name }}
+
+Each scenario lives at `extensions/molecule/<target>/` with:
+
+- `molecule.yml` — scenario overrides (shared ansible-native config is `../config.yml`)
+- `converge.yml` — `include_role` of playbook-adjacent role `content`
+- `roles/content/` — former `tests/integration/targets/<target>/` role tree
+
+Shared across scenarios:
+
+- `extensions/molecule/config.yml` — ansible-native executor + `test_sequence`
+- `extensions/molecule/inventory.yml` — localhost with `ansible_connection: local`
+
+## Finalize checklist
+
+1. Confirm shared inventory matches how the old targets ran (localhost vs containers). Override per scenario only when needed.
+2. Remove obsolete ansible-test metadata under `roles/content/` (`aliases`, setup-only `meta`) when it no longer applies.
+3. Run `molecule test -s <target>` for each migrated scenario (collection root; ADE/venv as usual).
+4. Update CI (tox-ansible / GitHub Actions) so migrated targets run via Molecule, not ansible-test integration.
+5. Remove empty `tests/integration/targets/` leftovers; decide whether to keep or drop `tests/integration/test_integration.py` / pytest-ansible bridges.
+6. Commit the scenario tree and delete any hybrid stubs you no longer need.
+
+Agent assist: open `.agents/skills/molecule-migrate-finalize/SKILL.md` (or ask your coding agent to follow that skill).

--- a/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
+++ b/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: molecule-migrate-finalize
+description: >-
+  Finalize a collection after ansible-creator migrate molecule moved
+  tests/integration/targets into extensions/molecule scenarios. Use when the
+  user says migrate finalize, post-migrate molecule, or after running
+  ansible-creator migrate molecule.
+---
+
+# Finalize Molecule migration
+
+Mechanical migration is done. Help the maintainer finish a safe, runnable Molecule layout.
+
+## Context
+
+- Scenarios: `extensions/molecule/<target>/`
+- Role content: `extensions/molecule/<target>/roles/content/` (former ansible-test target)
+- Shared ansible-native config: `extensions/molecule/config.yml` + `inventory.yml`
+- Checklist: `extensions/molecule/MIGRATE_NEXT_STEPS.md`
+
+## Steps
+
+1. List migrated scenarios under `extensions/molecule/` (ignore `utils/`, `config.yml`, `inventory.yml`, and `MIGRATE_NEXT_STEPS.md`).
+2. Confirm shared inventory (`ansible_connection: local` on localhost) matches how the old targets ran. Add scenario-local inventory only when a target needs something else; do not invent cloud creds.
+3. Inspect `roles/content/` for ansible-test-only files (`aliases`, `runme.sh`, setup deps). Remove or document anything Molecule will not honor.
+4. From the collection root, run `molecule test -s <target>` (or `molecule test --all` when appropriate). Fix playbook/role path issues first if converge fails to find role `content`.
+5. Update CI/tox so integration for migrated targets invokes Molecule, not `ansible-test integration`.
+6. Clean empty `tests/integration/targets/` dirs; note remaining script-shaped targets that were skipped.
+7. Summarize what changed, what still needs human platform/CI decisions, and any scenarios that failed verification.

--- a/src/ansible_creator/resources/common/molecule_migrate/config.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/config.yml
@@ -1,0 +1,12 @@
+---
+# Shared ansible-native config for migrated scenarios.
+# ADE/tox installs the collection; prerun would fight that.
+prerun: false
+ansible:
+  executor:
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_SCENARIO_DIRECTORY}/../inventory.yml
+scenario:
+  test_sequence:
+    - converge

--- a/src/ansible_creator/resources/common/molecule_migrate/converge.yml.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/converge.yml.j2
@@ -1,0 +1,9 @@
+---
+# Purpose: run the migrated ansible-test integration target as a Molecule scenario.
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include migrated integration target
+      ansible.builtin.include_role:
+        name: content

--- a/src/ansible_creator/resources/common/molecule_migrate/inventory.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/inventory.yml
@@ -1,0 +1,6 @@
+---
+# Shared inventory for ansible-native migrated scenarios (localhost / connection local).
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/src/ansible_creator/resources/common/molecule_migrate/molecule.yml.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/molecule.yml.j2
@@ -1,0 +1,4 @@
+---
+# Migrated from tests/integration/targets/{{ target_name }}
+# Shared ansible-native config + inventory live in extensions/molecule/
+# (../config.yml, ../inventory.yml). Override here only when needed.

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -1,0 +1,277 @@
+"""Definitions for ansible-creator migrate action."""
+
+from __future__ import annotations
+
+import shutil
+
+from importlib import resources as impl_resources
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ansible_creator.exceptions import CreatorError
+from ansible_creator.templar import Templar
+from ansible_creator.types import TemplateData
+from ansible_creator.utils import ask_yes_no, expand_path
+
+
+if TYPE_CHECKING:
+    from ansible_creator.config import Config
+    from ansible_creator.output import Output
+
+RESOURCE_PACKAGE = "ansible_creator.resources.common.molecule_migrate"
+TASK_MAIN_NAMES = ("tasks/main.yml", "tasks/main.yaml")
+
+
+class Migrate:
+    """Class to handle the migrate subcommand."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize the migrate action.
+
+        Args:
+            config: App configuration object.
+        """
+        self._migrate_type: str = config.migrate_type
+        self._target_name: str = config.target_name
+        self._migrate_all: bool = config.migrate_all
+        self._keep_targets: bool = config.keep_targets
+        self._collection_path: Path = expand_path(str(config.path))
+        self._force = config.force
+        self._overwrite = config.overwrite
+        self._no_overwrite = config.no_overwrite
+        self._skip_collection_check = config.skip_collection_check
+        self.output: Output = config.output
+        self.templar = Templar()
+        self._resource_root = impl_resources.files(RESOURCE_PACKAGE)
+
+    def run(self) -> None:
+        """Start the migration."""
+        if self._migrate_type != "molecule":
+            msg = f"Unsupported migrate type: {self._migrate_type!r}. Choose from: molecule"
+            raise CreatorError(msg)
+
+        self._check_path_exists()
+        self._check_collection_path()
+        self._migrate_molecule()
+
+    def _check_path_exists(self) -> None:
+        """Validate the provided collection path.
+
+        Raises:
+            CreatorError: If the path does not exist.
+        """
+        if not self._collection_path.exists():
+            msg = (
+                f"The path {self._collection_path} does not exist. "
+                "Please provide an existing directory."
+            )
+            raise CreatorError(msg)
+
+    def _check_collection_path(self) -> None:
+        """Validate that the path is an Ansible collection.
+
+        Raises:
+            CreatorError: If the path is not a collection path.
+        """
+        if self._skip_collection_check:
+            return
+
+        galaxy_file_path = self._collection_path / "galaxy.yml"
+        if not galaxy_file_path.is_file():
+            msg = (
+                f"The path {self._collection_path} is not a valid Ansible collection path. "
+                "Please provide the root path of a valid ansible collection."
+            )
+            raise CreatorError(msg)
+
+    def _migrate_molecule(self) -> None:
+        """Migrate ansible-test integration targets into Molecule scenarios."""
+        if self._migrate_all and self._target_name:
+            msg = "Specify either a target name or --all, not both."
+            raise CreatorError(msg)
+        if not self._migrate_all and not self._target_name:
+            msg = "Specify a target name or --all."
+            raise CreatorError(msg)
+
+        targets_dir = self._collection_path / "tests" / "integration" / "targets"
+        if not targets_dir.is_dir():
+            msg = f"No integration targets directory found at {targets_dir}."
+            raise CreatorError(msg)
+
+        if self._migrate_all:
+            candidates = sorted(path.name for path in targets_dir.iterdir() if path.is_dir())
+        else:
+            candidates = [self._target_name]
+
+        migrated: list[str] = []
+        skipped: list[str] = []
+
+        for name in candidates:
+            source = targets_dir / name
+            if not source.is_dir():
+                msg = f"Integration target not found: {source}"
+                raise CreatorError(msg)
+            if not self._is_role_shaped(source):
+                self.output.warning(
+                    msg=(
+                        f"Skipping {name!r}: not a role-shaped target "
+                        f"(expected tasks/main.yml or tasks/main.yaml)."
+                    ),
+                )
+                skipped.append(name)
+                continue
+            self._migrate_one_target(name=name, source=source)
+            migrated.append(name)
+
+        if not migrated:
+            msg = "No role-shaped integration targets were migrated."
+            raise CreatorError(msg)
+
+        self._write_guidance_artifacts(migrated)
+        self._ensure_shared_config()
+        action = "copied" if self._keep_targets else "moved"
+        self.output.note(
+            msg=(
+                f"{action.capitalize()} {len(migrated)} integration target(s) into "
+                f"extensions/molecule/: {', '.join(migrated)}. "
+                "Next: open extensions/molecule/MIGRATE_NEXT_STEPS.md or invoke the "
+                "molecule-migrate-finalize agent skill."
+            ),
+        )
+        if skipped:
+            self.output.warning(msg=f"Skipped non-role targets: {', '.join(skipped)}")
+
+    @staticmethod
+    def _is_role_shaped(target_dir: Path) -> bool:
+        """Return True when the target looks like an Ansible role.
+
+        Args:
+            target_dir: Path to an integration target directory.
+
+        Returns:
+            Whether the target has tasks/main.yml or tasks/main.yaml.
+        """
+        return any((target_dir / relative).is_file() for relative in TASK_MAIN_NAMES)
+
+    def _migrate_one_target(self, name: str, source: Path) -> None:
+        """Migrate a single integration target into a Molecule scenario.
+
+        Args:
+            name: Target / scenario name.
+            source: Path to tests/integration/targets/<name>.
+
+        Raises:
+            CreatorError: On overwrite conflicts when not permitted.
+        """
+        scenario_dir = self._collection_path / "extensions" / "molecule" / name
+        content_dir = scenario_dir / "roles" / "content"
+        molecule_yml = scenario_dir / "molecule.yml"
+        converge_yml = scenario_dir / "converge.yml"
+
+        conflicts = [
+            path
+            for path in (scenario_dir, content_dir, molecule_yml, converge_yml)
+            if path.exists()
+        ]
+        if conflicts:
+            conflict_list = ", ".join(str(path) for path in conflicts)
+            if self._no_overwrite:
+                msg = (
+                    f"The following path(s) already exist and --no-overwrite was set: "
+                    f"{conflict_list}"
+                )
+                raise CreatorError(msg)
+            if not (self._force or self._overwrite):
+                question = (
+                    f"Path(s) already exist for scenario {name!r}: {conflict_list}. Overwrite?"
+                )
+                if not ask_yes_no(question):
+                    msg = (
+                        f"The program aborted due to existing content for scenario {name!r}. "
+                        "Re-run with --overwrite to continue."
+                    )
+                    raise CreatorError(msg)
+
+            if scenario_dir.exists():
+                shutil.rmtree(scenario_dir)
+
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        content_dir.parent.mkdir(parents=True, exist_ok=True)
+        template_data = TemplateData(scenario_name=name, target_name=name)
+        molecule_yml.write_text(
+            self._render_template("molecule.yml.j2", template_data),
+            encoding="utf-8",
+        )
+        converge_yml.write_text(
+            self._render_template("converge.yml.j2", template_data),
+            encoding="utf-8",
+        )
+
+        if self._keep_targets:
+            shutil.copytree(source, content_dir)
+        else:
+            shutil.move(str(source), str(content_dir))
+
+        self.output.debug(msg=f"Migrated integration target {name!r} to {scenario_dir}")
+
+    def _render_template(self, filename: str, data: TemplateData) -> str:
+        """Load and render a migrate template.
+
+        Args:
+            filename: Template filename under the molecule_migrate resource package.
+            data: Template data.
+
+        Returns:
+            Rendered template content.
+        """
+        template = (self._resource_root / filename).read_text(encoding="utf-8")
+        return self.templar.render_from_content(template=template, data=data)
+
+    def _write_guidance_artifacts(self, migrated: list[str]) -> None:
+        """Write next-steps checklist and agent skill into the collection.
+
+        Args:
+            migrated: Names of targets migrated in this run.
+        """
+        molecule_root = self._collection_path / "extensions" / "molecule"
+        molecule_root.mkdir(parents=True, exist_ok=True)
+
+        next_steps = molecule_root / "MIGRATE_NEXT_STEPS.md"
+        template_data = TemplateData(
+            scenario_name=", ".join(migrated),
+            target_name=", ".join(migrated),
+        )
+        next_steps.write_text(
+            self._render_template("MIGRATE_NEXT_STEPS.md.j2", template_data),
+            encoding="utf-8",
+        )
+
+        skill_dest = (
+            self._collection_path
+            / ".agents"
+            / "skills"
+            / "molecule-migrate-finalize"
+            / "SKILL.md"
+        )
+        skill_dest.parent.mkdir(parents=True, exist_ok=True)
+        skill_content = (self._resource_root / "SKILL.md").read_text(encoding="utf-8")
+        if not skill_dest.exists() or skill_dest.read_text(encoding="utf-8") != skill_content:
+            if skill_dest.exists() and self._no_overwrite:
+                self.output.warning(
+                    msg=f"Skipped updating {skill_dest} because --no-overwrite was set.",
+                )
+            else:
+                skill_dest.write_text(skill_content, encoding="utf-8")
+
+    def _ensure_shared_config(self) -> None:
+        """Write shared ansible-native config + inventory once if missing."""
+        molecule_root = self._collection_path / "extensions" / "molecule"
+        molecule_root.mkdir(parents=True, exist_ok=True)
+        for filename in ("config.yml", "inventory.yml"):
+            dest = molecule_root / filename
+            if dest.exists():
+                continue
+            dest.write_text(
+                (self._resource_root / filename).read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -802,12 +802,16 @@ class TemplateData:
         ee_scm_token_vars: Pre-computed list of token env var names from scm_servers.
         ee_file_name: Name of the EE definition file.
         scm_provider: SCM provider for documentation templates (github or gitlab).
+        scenario_name: Molecule scenario name (migrate molecule).
+        target_name: Integration target name (migrate molecule).
     """
 
     resource_type: str = ""
     plugin_type: str = ""
     plugin_name: str = ""
     role_name: str = ""
+    scenario_name: str = ""
+    target_name: str = ""
     additions: dict[str, dict[str, dict[str, str | bool]]] = field(default_factory=dict)
     collection_name: str = ""
     creator_version: str = ""

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -1,0 +1,41 @@
+"""Integration tests for ansible-creator migrate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.defaults import CREATOR_BIN
+
+
+if TYPE_CHECKING:
+    from tests.conftest import CliRunCallable
+
+
+def test_migrate_molecule_cli(cli: CliRunCallable, tmp_path: Path) -> None:
+    """Migrate a role-shaped integration target via the CLI."""
+    collection = tmp_path / "ns" / "col"
+    targets = collection / "tests" / "integration" / "targets" / "sample"
+    tasks = targets / "tasks"
+    tasks.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 0.1.0\n")
+    (tasks / "main.yml").write_text("---\n- ansible.builtin.debug:\n    msg: ok\n")
+
+    result = cli(
+        f"{CREATOR_BIN} migrate molecule sample --path {collection}",
+        env={"NO_COLOR": "1"},
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Moved" in result.stdout or "moved" in result.stdout.lower()
+
+    scenario = collection / "extensions" / "molecule" / "sample"
+    assert (scenario / "molecule.yml").is_file()
+    assert (scenario / "converge.yml").is_file()
+    assert (scenario / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert not targets.exists()
+    assert (collection / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md").is_file()
+    assert (collection / "extensions" / "molecule" / "config.yml").is_file()
+    assert (collection / "extensions" / "molecule" / "inventory.yml").is_file()
+    assert (collection / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md").is_file()
+    assert "platforms:" not in (scenario / "molecule.yml").read_text()
+    assert "name: content" in (scenario / "converge.yml").read_text()

--- a/tests/integration/test_no_input.py
+++ b/tests/integration/test_no_input.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
         pytest.param("add plugin --help", "", id="add-plugin-help"),
         pytest.param("init", "Missing required argument 'project-type'.", id="init"),
         pytest.param("init --help", "", id="init-help"),
+        pytest.param("migrate", "Missing required argument 'migrate-type'.", id="migrate"),
+        pytest.param("migrate --help", "", id="migrate-help"),
     ),
 )
 def test_run_no_input(cli: CliRunCallable, args: str, error_msg: str) -> None:

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -1,0 +1,178 @@
+# cspell: ignore dcmp
+"""Unit tests for ansible-creator migrate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ansible_creator.config import Config
+from ansible_creator.exceptions import CreatorError
+from ansible_creator.subcommands.migrate import Migrate
+
+
+if TYPE_CHECKING:
+    from ansible_creator.output import Output
+
+
+def _write_role_target(targets_dir: Path, name: str, *, main_name: str = "main.yml") -> Path:
+    target = targets_dir / name
+    tasks = target / "tasks"
+    tasks.mkdir(parents=True)
+    (tasks / main_name).write_text("---\n- name: Ping\n  ansible.builtin.debug:\n    msg: hi\n")
+    return target
+
+
+def _seed_collection(tmp_path: Path) -> Path:
+    collection = tmp_path / "ns" / "col"
+    collection.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    _write_role_target(targets, "alpha")
+    _write_role_target(targets, "beta", main_name="main.yaml")
+    script_only = targets / "scripty"
+    script_only.mkdir()
+    (script_only / "runme.sh").write_text("#!/bin/sh\necho hi\n")
+    return collection
+
+
+@pytest.fixture(name="collection_path")
+def fixture_collection_path(tmp_path: Path) -> Path:
+    return _seed_collection(tmp_path)
+
+
+def _migrate_config(
+    output: Output,
+    path: Path,
+    *,
+    target_name: str = "",
+    migrate_all: bool = False,
+    keep_targets: bool = False,
+    overwrite: bool = False,
+    no_overwrite: bool = False,
+) -> Config:
+    return Config(
+        creator_version="0.0.1",
+        output=output,
+        subcommand="migrate",
+        migrate_type="molecule",
+        target_name=target_name,
+        migrate_all=migrate_all,
+        keep_targets=keep_targets,
+        path=str(path),
+        overwrite=overwrite,
+        no_overwrite=no_overwrite,
+    )
+
+
+def test_migrate_single_target_moves(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha")).run()
+
+    scenario = collection_path / "extensions" / "molecule" / "alpha"
+    assert (scenario / "molecule.yml").is_file()
+    assert (scenario / "converge.yml").is_file()
+    assert (scenario / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert not (collection_path / "tests" / "integration" / "targets" / "alpha").exists()
+    assert (collection_path / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md").is_file()
+    assert (
+        collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
+    ).is_file()
+    assert (collection_path / "extensions" / "molecule" / "config.yml").is_file()
+    assert (collection_path / "extensions" / "molecule" / "inventory.yml").is_file()
+    assert "prerun: false" in (
+        collection_path / "extensions" / "molecule" / "config.yml"
+    ).read_text()
+    assert "ansible_connection: local" in (
+        collection_path / "extensions" / "molecule" / "inventory.yml"
+    ).read_text()
+    molecule_yml = (scenario / "molecule.yml").read_text()
+    assert "platforms:" not in molecule_yml
+    assert "provisioner:" not in molecule_yml
+    converge = (scenario / "converge.yml").read_text()
+    assert "name: content" in converge
+    assert "playbook_dir" not in converge
+
+
+def test_migrate_all_skips_non_role(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, migrate_all=True)).run()
+
+    molecule_root = collection_path / "extensions" / "molecule"
+    assert (molecule_root / "alpha" / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert (molecule_root / "beta" / "roles" / "content" / "tasks" / "main.yaml").is_file()
+    assert not (molecule_root / "scripty").exists()
+    assert (collection_path / "tests" / "integration" / "targets" / "scripty").is_dir()
+
+
+def test_migrate_keep_targets(collection_path: Path, output: Output) -> None:
+    Migrate(
+        _migrate_config(output, collection_path, target_name="alpha", keep_targets=True),
+    ).run()
+
+    assert (collection_path / "tests" / "integration" / "targets" / "alpha").is_dir()
+    assert (
+        collection_path
+        / "extensions"
+        / "molecule"
+        / "alpha"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yml"
+    ).is_file()
+
+
+def test_migrate_requires_target_or_all(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="target name or --all"):
+        Migrate(_migrate_config(output, collection_path)).run()
+
+
+def test_migrate_rejects_target_and_all(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="not both"):
+        Migrate(
+            _migrate_config(output, collection_path, target_name="alpha", migrate_all=True),
+        ).run()
+
+
+def test_migrate_missing_target(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="not found"):
+        Migrate(_migrate_config(output, collection_path, target_name="missing")).run()
+
+
+def test_migrate_no_overwrite(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    with pytest.raises(CreatorError, match="--no-overwrite"):
+        Migrate(
+            _migrate_config(
+                output,
+                collection_path,
+                target_name="beta",
+                keep_targets=True,
+                no_overwrite=True,
+            ),
+        ).run()
+
+
+def test_migrate_overwrite(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    Migrate(
+        _migrate_config(
+            output,
+            collection_path,
+            target_name="beta",
+            keep_targets=True,
+            overwrite=True,
+        ),
+    ).run()
+    assert (
+        collection_path
+        / "extensions"
+        / "molecule"
+        / "beta"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yaml"
+    ).is_file()


### PR DESCRIPTION
## Summary
- Add `ansible-creator migrate molecule [<target>|--all]` to move role-shaped `tests/integration/targets/` trees into real on-disk Molecule scenarios under `extensions/molecule/<target>/`.
- Use **ansible-native** shared config: `extensions/molecule/config.yml` + `inventory.yml` (`localhost` / `ansible_connection: local`); playbook-adjacent `roles/content/` + `include_role: name: content`.
- Ship `MIGRATE_NEXT_STEPS.md`, agent skill, and docs in `docs/agents.md`. Layout matches what landed in [ansible-collections/ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444).

## Test plan
- [ ] `pytest tests/units/test_migrate.py`
- [ ] `pytest tests/integration/test_migrate.py` (tox env with installed CLI)
- [ ] Smoke: `ansible-creator migrate molecule --all --path /path/to/collection` on a collection with role-shaped targets
- [ ] `molecule test -s <scenario>` after migrate (with ADE/collection install)

Related: ansible/handbook#1520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `migrate molecule` command to convert Ansible integration targets into Molecule scenarios.
  * Supports migrating a selected target or all eligible targets, preserving originals, and handling overwrite conflicts.
  * Generates Molecule scenario files, shared configuration, inventory, and migration follow-up guidance.

* **Documentation**
  * Added comprehensive migration instructions, finalization steps, and troubleshooting guidance.

* **Tests**
  * Added coverage for successful migrations, validation errors, target preservation, and overwrite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->