### PR TITLE
feat: add migrate molecule for ansible-test integration targets

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -11,7 +11,6 @@ argnames
 argspec
 argvalues
 capsys
-creds
 delenv
 devfile
 devspaces

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -11,6 +11,7 @@ argnames
 argspec
 argvalues
 capsys
+creds
 delenv
 devfile
 devspaces
@@ -27,9 +28,12 @@ myuser
 netcommon
 notesdir
 prek
+prerun
 pydoclint
 rulebook
 rulebooks
+runme
+scripty
 sshpass
 sysargs
 testcol

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -128,7 +128,7 @@ A playbook project orchestrates landscapes and types via one or more playbooks, 
 - [ ] Increase reliability and reduce costs through testing
 - [ ] Test playbooks in non-production environments first
 - [ ] Validate changes before deploying to production
-    - [ ] Use `molecule` or similar tools for role testing
+  - [ ] Use `molecule` or similar tools for role testing
 - [ ] Test against multiple platforms when supporting diverse environments
 - [ ] Automate testing as part of CI/CD pipeline
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,6 +13,7 @@ This document provides comprehensive guidelines for AI agents working with Ansib
   - [Starting Approach](#starting-approach)
   - [Testing and Validation](#testing-and-validation)
     - [Testing Strategies](#testing-strategies)
+    - [Migrating ansible-test integration targets to Molecule](#migrating-ansible-test-integration-targets-to-molecule)
     - [Smoke Testing](#smoke-testing)
 - [Coding Standards](#coding-standards)
   - [Formatting](#formatting)
@@ -127,9 +128,39 @@ A playbook project orchestrates landscapes and types via one or more playbooks, 
 - [ ] Increase reliability and reduce costs through testing
 - [ ] Test playbooks in non-production environments first
 - [ ] Validate changes before deploying to production
-- [ ] Use `molecule` or similar tools for role testing
+    - [ ] Use `molecule` or similar tools for role testing
 - [ ] Test against multiple platforms when supporting diverse environments
 - [ ] Automate testing as part of CI/CD pipeline
+
+#### Migrating ansible-test integration targets to Molecule
+
+Use `ansible-creator migrate molecule` to move role-shaped
+`tests/integration/targets/<name>/` trees into real on-disk scenarios:
+
+```text
+ansible-creator migrate molecule <target> [--path PATH]
+ansible-creator migrate molecule --all [--path PATH]
+```
+
+Default behavior **moves** the target into:
+
+```text
+extensions/molecule/
+  config.yml                # ansible-native shared config
+  inventory.yml             # localhost / ansible_connection: local
+  <target>/
+    molecule.yml            # thin; overrides only if needed
+    converge.yml            # include_role name: content
+    roles/content/          # former target role tree
+```
+
+After migration:
+
+1. Follow `extensions/molecule/MIGRATE_NEXT_STEPS.md`
+2. Use `.agents/skills/molecule-migrate-finalize/SKILL.md` for agent-assisted finalization
+3. Review shared inventory, drop obsolete `aliases`, run `molecule test -s <target>`, update CI
+
+Use `--keep-targets` only when you must retain ansible-test paths temporarily (hybrid). Prefer completing the move rather than leaving dual trees forever.
 
 #### Smoke Testing
 

--- a/src/ansible_creator/_arg_parser_migrate.py
+++ b/src/ansible_creator/_arg_parser_migrate.py
@@ -1,0 +1,104 @@
+"""Migrate subcommand argument parsing for ansible-creator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    import argparse
+
+    from ansible_creator.arg_parser import SubParser
+
+
+class MigrateParserMixin:
+    """Mixin providing migrate subcommand parsers.
+
+    Attributes:
+        migrate_parser: Parser for the migrate subcommand.
+    """
+
+    migrate_parser: argparse.ArgumentParser | None
+
+    def _add_args_common(self, parser: argparse.ArgumentParser) -> None:
+        """Add common arguments to the parser.
+
+        Args:
+            parser: The parser to add common arguments to
+        """
+
+    def _add_overwrite(self, parser: argparse.ArgumentParser) -> None:
+        """Add overwrite arguments to the parser.
+
+        Args:
+            parser: The parser to add overwrite arguments to
+        """
+
+    def _migrate(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Migrate existing Ansible content into newer layouts.
+
+        Args:
+            subparser: The subparser to add migrate to
+        """
+        parser = subparser.add_parser(
+            "migrate",
+            help="Migrate existing Ansible content into newer layouts.",
+        )
+        self.migrate_parser = parser
+        migrate_sub = parser.add_subparsers(
+            dest="migrate_type",
+            metavar="migrate-type",
+            required=False,
+        )
+        self._migrate_molecule(subparser=migrate_sub)
+
+    def _migrate_molecule(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Migrate ansible-test integration targets into Molecule scenarios.
+
+        Args:
+            subparser: The subparser to add molecule migrate to
+        """
+        parser = subparser.add_parser(
+            "molecule",
+            help=(
+                "Move ansible-test integration targets under "
+                "extensions/molecule/ as real Molecule scenarios."
+            ),
+        )
+        parser.add_argument(
+            "target_name",
+            nargs="?",
+            default="",
+            help=(
+                "Integration target name under tests/integration/targets/. Omit when using --all."
+            ),
+        )
+        parser.add_argument(
+            "--path",
+            "-p",
+            default="./",
+            dest="path",
+            metavar="path",
+            help=(
+                "The path to the Ansible collection. The default is the current working directory."
+            ),
+        )
+        parser.add_argument(
+            "--all",
+            dest="migrate_all",
+            default=False,
+            action="store_true",
+            help="Migrate all role-shaped integration targets.",
+        )
+        parser.add_argument(
+            "--keep-targets",
+            dest="keep_targets",
+            default=False,
+            action="store_true",
+            help=(
+                "Copy targets into scenarios instead of moving them "
+                "(keeps ansible-test paths for hybrid use)."
+            ),
+        )
+        self._add_overwrite(parser)
+        self._add_args_common(parser)

--- a/src/ansible_creator/api.py
+++ b/src/ansible_creator/api.py
@@ -185,9 +185,9 @@ class V1:
         args = vars(namespace)
         output, messages = self._build_output(args, kwargs)
 
-        # Determine the output path -- only init/add need a workspace dir
+        # Determine the output path -- init/add/migrate need a workspace dir
         subcommand = command_path[0]
-        needs_workspace = subcommand in ("init", "add")
+        needs_workspace = subcommand in ("init", "add", "migrate")
         output_dir: Path | None = None
 
         if needs_workspace:
@@ -443,6 +443,6 @@ class V1:
         """
         if subcommand == "init" and "init_path" in kwargs:
             return str(kwargs["init_path"])
-        if subcommand == "add" and "path" in kwargs:
+        if subcommand in ("add", "migrate") and "path" in kwargs:
             return str(kwargs["path"])
         return None

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -47,6 +47,7 @@ class Parser:
         self.add_parser: argparse.ArgumentParser | None = None
         self.add_resource_parser: argparse.ArgumentParser | None = None
         self.add_plugin_parser: argparse.ArgumentParser | None = None
+        self.migrate_parser: argparse.ArgumentParser | None = None
         self.exit_code: int = 0
 
     def build_parser(self) -> CustomArgumentParser:
@@ -71,6 +72,7 @@ class Parser:
         )
         self._add(subparser=subparser)  # type: ignore[arg-type]
         self._init(subparser=subparser)  # type: ignore[arg-type]
+        self._migrate(subparser=subparser)  # type: ignore[arg-type]
         self._schema(subparser=subparser)  # type: ignore[arg-type]
         return parser
 
@@ -149,6 +151,21 @@ class Parser:
                     prefix=Level.ERROR,
                     message="Missing required argument 'plugin-type'.\n"
                     "Choose from: action, filter, lookup, module, test",
+                )
+            )
+            self.exit_code = os.EX_USAGE
+
+        # Show help for 'ansible-creator migrate' without arguments
+        if (
+            self.args.subcommand == "migrate"
+            and getattr(self.args, "migrate_type", None) is None
+            and self.migrate_parser
+        ):
+            self.migrate_parser.print_help(sys.stderr)
+            self.pending_logs.append(
+                Msg(
+                    prefix=Level.ERROR,
+                    message="Missing required argument 'migrate-type'.\nChoose from: molecule",
                 )
             )
             self.exit_code = os.EX_USAGE
@@ -644,6 +661,77 @@ class Parser:
         self._init_collection(subparser=subparser)
         self._init_playbook(subparser=subparser)
         self._init_ee_project(subparser=subparser)
+
+    def _migrate(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Migrate existing Ansible content into newer layouts.
+
+        Args:
+            subparser: The subparser to add migrate to
+        """
+        parser = subparser.add_parser(
+            "migrate",
+            help="Migrate existing Ansible content into newer layouts.",
+        )
+        self.migrate_parser = parser
+        migrate_sub = parser.add_subparsers(
+            dest="migrate_type",
+            metavar="migrate-type",
+            required=False,
+        )
+        self._migrate_molecule(subparser=migrate_sub)
+
+    def _migrate_molecule(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Migrate ansible-test integration targets into Molecule scenarios.
+
+        Args:
+            subparser: The subparser to add molecule migrate to
+        """
+        parser = subparser.add_parser(
+            "molecule",
+            help=(
+                "Move ansible-test integration targets under "
+                "extensions/molecule/ as real Molecule scenarios."
+            ),
+        )
+        parser.add_argument(
+            "target_name",
+            nargs="?",
+            default="",
+            help=(
+                "Integration target name under tests/integration/targets/. "
+                "Omit when using --all."
+            ),
+        )
+        parser.add_argument(
+            "--path",
+            "-p",
+            default="./",
+            dest="path",
+            metavar="path",
+            help=(
+                "The path to the Ansible collection. The default is the "
+                "current working directory."
+            ),
+        )
+        parser.add_argument(
+            "--all",
+            dest="migrate_all",
+            default=False,
+            action="store_true",
+            help="Migrate all role-shaped integration targets.",
+        )
+        parser.add_argument(
+            "--keep-targets",
+            dest="keep_targets",
+            default=False,
+            action="store_true",
+            help=(
+                "Copy targets into scenarios instead of moving them "
+                "(keeps ansible-test paths for hybrid use)."
+            ),
+        )
+        self._add_overwrite(parser)
+        self._add_args_common(parser)
 
     def _schema(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
         """Output CLI schema as JSON.

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -14,6 +14,7 @@ from ansible_creator.bundles import get_init_bundle_names
 from ansible_creator.output import Level, Msg
 
 from ._arg_parser_custom import CustomArgumentParser
+from ._arg_parser_migrate import MigrateParserMixin
 
 
 try:
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
     SubParser: TypeAlias = argparse._SubParsersAction  # noqa: SLF001
 
 
-class Parser:
+class Parser(MigrateParserMixin):
     """A parser for the command line arguments."""
 
     def __init__(self) -> None:
@@ -661,77 +662,6 @@ class Parser:
         self._init_collection(subparser=subparser)
         self._init_playbook(subparser=subparser)
         self._init_ee_project(subparser=subparser)
-
-    def _migrate(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
-        """Migrate existing Ansible content into newer layouts.
-
-        Args:
-            subparser: The subparser to add migrate to
-        """
-        parser = subparser.add_parser(
-            "migrate",
-            help="Migrate existing Ansible content into newer layouts.",
-        )
-        self.migrate_parser = parser
-        migrate_sub = parser.add_subparsers(
-            dest="migrate_type",
-            metavar="migrate-type",
-            required=False,
-        )
-        self._migrate_molecule(subparser=migrate_sub)
-
-    def _migrate_molecule(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
-        """Migrate ansible-test integration targets into Molecule scenarios.
-
-        Args:
-            subparser: The subparser to add molecule migrate to
-        """
-        parser = subparser.add_parser(
-            "molecule",
-            help=(
-                "Move ansible-test integration targets under "
-                "extensions/molecule/ as real Molecule scenarios."
-            ),
-        )
-        parser.add_argument(
-            "target_name",
-            nargs="?",
-            default="",
-            help=(
-                "Integration target name under tests/integration/targets/. "
-                "Omit when using --all."
-            ),
-        )
-        parser.add_argument(
-            "--path",
-            "-p",
-            default="./",
-            dest="path",
-            metavar="path",
-            help=(
-                "The path to the Ansible collection. The default is the "
-                "current working directory."
-            ),
-        )
-        parser.add_argument(
-            "--all",
-            dest="migrate_all",
-            default=False,
-            action="store_true",
-            help="Migrate all role-shaped integration targets.",
-        )
-        parser.add_argument(
-            "--keep-targets",
-            dest="keep_targets",
-            default=False,
-            action="store_true",
-            help=(
-                "Copy targets into scenarios instead of moving them "
-                "(keeps ansible-test paths for hybrid use)."
-            ),
-        )
-        self._add_overwrite(parser)
-        self._add_args_common(parser)
 
     def _schema(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
         """Output CLI schema as JSON.

--- a/src/ansible_creator/bundles.py
+++ b/src/ansible_creator/bundles.py
@@ -18,6 +18,7 @@ _INIT_EXCLUDED_BUNDLES: frozenset[str] = frozenset(
         "ee-ci",
         "execution-environment",
         "play-argspec",
+        "molecule_migrate",
     },
 )
 

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -54,6 +54,10 @@ class Config:
         scm_provider: SCM provider for EE CI scaffolding (github or gitlab).
         include: Resource bundles to include during init (default: all).
         exclude: Resource bundles to exclude during init.
+        migrate_type: The migrate destination type (e.g. molecule).
+        target_name: Integration target name to migrate (omit with --all).
+        migrate_all: Migrate all role-shaped integration targets.
+        keep_targets: Copy targets into scenarios instead of moving them.
     """
 
     creator_version: str
@@ -88,6 +92,10 @@ class Config:
     scm_provider: str = "github"
     include: Sequence[str] = field(default_factory=lambda: ["all"])
     exclude: Sequence[str] = field(default_factory=list)
+    migrate_type: str = ""
+    target_name: str = ""
+    migrate_all: bool = False
+    keep_targets: bool = False
 
     def __post_init__(self) -> None:
         """Post process config values."""

--- a/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
@@ -1,0 +1,28 @@
+---
+# Molecule migration next steps
+
+ansible-creator migrated these integration targets into Molecule scenarios:
+
+{{ target_name }}
+
+Each scenario lives at `extensions/molecule/<target>/` with:
+
+- `molecule.yml` — scenario overrides (shared ansible-native config is `../config.yml`)
+- `converge.yml` — `include_role` of playbook-adjacent role `content`
+- `roles/content/` — former `tests/integration/targets/<target>/` role tree
+
+Shared across scenarios:
+
+- `extensions/molecule/config.yml` — ansible-native executor + `test_sequence`
+- `extensions/molecule/inventory.yml` — localhost with `ansible_connection: local`
+
+## Finalize checklist
+
+1. Confirm shared inventory matches how the old targets ran (localhost vs containers). Override per scenario only when needed.
+2. Remove obsolete ansible-test metadata under `roles/content/` (`aliases`, setup-only `meta`) when it no longer applies.
+3. Run `molecule test -s <target>` for each migrated scenario (collection root; ADE/venv as usual).
+4. Update CI (tox-ansible / GitHub Actions) so migrated targets run via Molecule, not ansible-test integration.
+5. Remove empty `tests/integration/targets/` leftovers; decide whether to keep or drop `tests/integration/test_integration.py` / pytest-ansible bridges.
+6. Commit the scenario tree and delete any hybrid stubs you no longer need.
+
+Agent assist: open `.agents/skills/molecule-migrate-finalize/SKILL.md` (or ask your coding agent to follow that skill).

--- a/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
@@ -1,7 +1,7 @@
 ---
 # Molecule migration next steps
 
-ansible-creator migrated these integration targets into Molecule scenarios:
+ansible-creator just migrated these integration targets into Molecule scenarios:
 
 {{ target_name }}
 
@@ -13,16 +13,34 @@ Each scenario lives at `extensions/molecule/<target>/` with:
 
 Shared across scenarios:
 
-- `extensions/molecule/config.yml` — ansible-native executor + `test_sequence`
+- `extensions/molecule/config.yml` — ansible-native executor, `shared_state: true`, `test_sequence`
 - `extensions/molecule/inventory.yml` — localhost with `ansible_connection: local`
+- `extensions/molecule/default/molecule.yml` — lifecycle manager (create/destroy)
+{% if cross_dependencies %}
+
+## Cross-target role dependencies detected
+
+The following targets reference other targets via `meta/main.yml` dependencies.
+These cannot be resolved automatically — they need analysis to determine whether
+the dependency is **shared infrastructure** (belongs in `default/prepare.yml`)
+or **per-scenario preparation** (belongs in the scenario's own `prepare.yml`).
+
+{{ cross_dependencies }}
+
+Use the `molecule-migrate-finalize` agent skill or review the Molecule
+shared-state documentation to restructure these into proper Molecule lifecycle
+phases: <https://docs.ansible.com/projects/molecule/getting-started-collections/>
+{% endif %}
 
 ## Finalize checklist
 
-1. Confirm shared inventory matches how the old targets ran (localhost vs containers). Override per scenario only when needed.
-2. Remove obsolete ansible-test metadata under `roles/content/` (`aliases`, setup-only `meta`) when it no longer applies.
-3. Run `molecule test -s <target>` for each migrated scenario (collection root; ADE/venv as usual).
-4. Update CI (tox-ansible / GitHub Actions) so migrated targets run via Molecule, not ansible-test integration.
-5. Remove empty `tests/integration/targets/` leftovers; decide whether to keep or drop `tests/integration/test_integration.py` / pytest-ansible bridges.
-6. Commit the scenario tree and delete any hybrid stubs you no longer need.
+1. **Analyze cross-target dependencies.** If any targets depend on setup roles (listed above or in `meta/main.yml`), decide how to map them into Molecule's lifecycle. Setup roles that create shared infrastructure belong in `default/prepare.yml`. Per-scenario prep belongs in each scenario's `prepare.yml`.
+2. **Split converge from verify.** ansible-test targets typically mix state application and assertions in `tasks/main.yml`. Molecule separates these into distinct lifecycle phases. Review each `roles/content/tasks/main.yml` for `assert` / `fail_when` / `stat` + check-mode tasks that validate outcomes. Move those into a `verify.yml` playbook at the scenario root so you can re-run `molecule verify` without re-converging — this is faster for iterative development and aligns with Molecule's intended workflow.
+3. Confirm shared inventory matches how the old targets ran (localhost vs containers). Override per scenario only when needed.
+4. Remove obsolete ansible-test metadata under `roles/content/` (`aliases`, setup-only `meta`) when it no longer applies.
+5. Run `molecule test -s <target>` for each migrated scenario (collection root; ADE/venv as usual).
+6. Update CI (tox-ansible / GitHub Actions) so migrated targets run via Molecule, not ansible-test integration.
+7. Remove empty `tests/integration/targets/` leftovers; decide whether to keep or drop `tests/integration/test_integration.py` / pytest-ansible bridges.
+8. Commit the scenario tree and delete any hybrid stubs you no longer need.
 
 Agent assist: open `.agents/skills/molecule-migrate-finalize/SKILL.md` (or ask your coding agent to follow that skill).

--- a/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/MIGRATE_NEXT_STEPS.md.j2
@@ -20,9 +20,9 @@ Shared across scenarios:
 
 ## Cross-target role dependencies detected
 
-The following targets reference other targets via `meta/main.yml` dependencies.
-These cannot be resolved automatically — they need analysis to determine whether
-the dependency is **shared infrastructure** (belongs in `default/prepare.yml`)
+The following targets reference other targets via `meta/main.yml` (or `meta/main.yaml`)
+dependencies. These cannot be resolved automatically — they need analysis to determine
+whether the dependency is **shared infrastructure** (belongs in `default/prepare.yml`)
 or **per-scenario preparation** (belongs in the scenario's own `prepare.yml`).
 
 {{ cross_dependencies }}
@@ -34,7 +34,7 @@ phases: <https://docs.ansible.com/projects/molecule/getting-started-collections/
 
 ## Finalize checklist
 
-1. **Analyze cross-target dependencies.** If any targets depend on setup roles (listed above or in `meta/main.yml`), decide how to map them into Molecule's lifecycle. Setup roles that create shared infrastructure belong in `default/prepare.yml`. Per-scenario prep belongs in each scenario's `prepare.yml`.
+1. **Analyze cross-target dependencies.** If any targets depend on setup roles (listed above or in `meta/main.yml` / `meta/main.yaml`), decide how to map them into Molecule's lifecycle. Setup roles that create shared infrastructure belong in `default/prepare.yml`. Per-scenario prep belongs in each scenario's `prepare.yml`.
 2. **Split converge from verify.** ansible-test targets typically mix state application and assertions in `tasks/main.yml`. Molecule separates these into distinct lifecycle phases. Review each `roles/content/tasks/main.yml` for `assert` / `fail_when` / `stat` + check-mode tasks that validate outcomes. Move those into a `verify.yml` playbook at the scenario root so you can re-run `molecule verify` without re-converging — this is faster for iterative development and aligns with Molecule's intended workflow.
 3. Confirm shared inventory matches how the old targets ran (localhost vs containers). Override per scenario only when needed.
 4. Remove obsolete ansible-test metadata under `roles/content/` (`aliases`, setup-only `meta`) when it no longer applies.

--- a/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
+++ b/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: molecule-migrate-finalize
+description: >-
+  Finalize a collection after ansible-creator migrate molecule moved
+  tests/integration/targets into extensions/molecule scenarios. Use when the
+  user says migrate finalize, post-migrate molecule, or after running
+  ansible-creator migrate molecule.
+---
+
+# Finalize Molecule migration
+
+Mechanical migration is done. Help the maintainer finish a safe, runnable Molecule layout.
+
+## Context
+
+- Scenarios: `extensions/molecule/<target>/`
+- Role content: `extensions/molecule/<target>/roles/content/` (former ansible-test target)
+- Shared ansible-native config: `extensions/molecule/config.yml` + `inventory.yml`
+- Checklist: `extensions/molecule/MIGRATE_NEXT_STEPS.md`
+
+## Steps
+
+1. List migrated scenarios under `extensions/molecule/` (ignore `utils/`, `config.yml`, `inventory.yml`, and `MIGRATE_NEXT_STEPS.md`).
+2. Confirm shared inventory (`ansible_connection: local` on localhost) matches how the old targets ran. Add scenario-local inventory only when a target needs something else; do not invent cloud creds.
+3. Inspect `roles/content/` for ansible-test-only files (`aliases`, `runme.sh`, setup deps). Remove or document anything Molecule will not honor.
+4. From the collection root, run `molecule test -s <target>` (or `molecule test --all` when appropriate). Fix playbook/role path issues first if converge fails to find role `content`.
+5. Update CI/tox so integration for migrated targets invokes Molecule, not `ansible-test integration`.
+6. Clean empty `tests/integration/targets/` dirs; note remaining script-shaped targets that were skipped.
+7. Summarize what changed, what still needs human platform/CI decisions, and any scenarios that failed verification.

--- a/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
+++ b/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
@@ -39,8 +39,8 @@ Reference: <https://docs.ansible.com/projects/molecule/getting-started-collectio
      config), fold it into `default/prepare.yml`.
    - If the dependency is *scenario-specific preparation* (test data, fixture setup),
      add a `prepare.yml` to that scenario.
-   - Remove the `meta/main.yml` dependency entries from migrated `roles/content/` — the
-     Molecule lifecycle replaces them.
+   - Remove the `meta/main.yml` (or `meta/main.yaml`) dependency entries from migrated
+     `roles/content/` — the Molecule lifecycle replaces them.
 
 3. **Split converge from verify.** ansible-test integration targets almost always mix state
    application and assertions in `tasks/main.yml`.  Molecule separates these into distinct

--- a/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
+++ b/src/ansible_creator/resources/common/molecule_migrate/SKILL.md
@@ -15,15 +15,60 @@ Mechanical migration is done. Help the maintainer finish a safe, runnable Molecu
 
 - Scenarios: `extensions/molecule/<target>/`
 - Role content: `extensions/molecule/<target>/roles/content/` (former ansible-test target)
-- Shared ansible-native config: `extensions/molecule/config.yml` + `inventory.yml`
+- Shared config: `extensions/molecule/config.yml` — ansible-native executor, `shared_state: true`
+- Inventory: `extensions/molecule/inventory.yml`
+- Default scenario: `extensions/molecule/default/molecule.yml` — lifecycle manager (create/destroy)
 - Checklist: `extensions/molecule/MIGRATE_NEXT_STEPS.md`
+
+## Architecture: shared-state model
+
+With `shared_state: true` in `config.yml`, Molecule delegates lifecycle management to the
+`default` scenario.  The `default` scenario owns `create` → `prepare` → `destroy`, and
+component scenarios only run `converge` → `verify`.  This mirrors the ansible-test model
+where `setup_*` roles run before dependent targets.
+
+Reference: <https://docs.ansible.com/projects/molecule/getting-started-collections/>
 
 ## Steps
 
-1. List migrated scenarios under `extensions/molecule/` (ignore `utils/`, `config.yml`, `inventory.yml`, and `MIGRATE_NEXT_STEPS.md`).
-2. Confirm shared inventory (`ansible_connection: local` on localhost) matches how the old targets ran. Add scenario-local inventory only when a target needs something else; do not invent cloud creds.
-3. Inspect `roles/content/` for ansible-test-only files (`aliases`, `runme.sh`, setup deps). Remove or document anything Molecule will not honor.
-4. From the collection root, run `molecule test -s <target>` (or `molecule test --all` when appropriate). Fix playbook/role path issues first if converge fails to find role `content`.
-5. Update CI/tox so integration for migrated targets invokes Molecule, not `ansible-test integration`.
-6. Clean empty `tests/integration/targets/` dirs; note remaining script-shaped targets that were skipped.
-7. Summarize what changed, what still needs human platform/CI decisions, and any scenarios that failed verification.
+1. Read `MIGRATE_NEXT_STEPS.md` for the list of migrated scenarios and any cross-target
+   dependencies that were detected.
+
+2. **Analyze cross-target dependencies.** For each dependency listed:
+   - If the dependency role provides *shared infrastructure* (common packages, services,
+     config), fold it into `default/prepare.yml`.
+   - If the dependency is *scenario-specific preparation* (test data, fixture setup),
+     add a `prepare.yml` to that scenario.
+   - Remove the `meta/main.yml` dependency entries from migrated `roles/content/` — the
+     Molecule lifecycle replaces them.
+
+3. **Split converge from verify.** ansible-test integration targets almost always mix state
+   application and assertions in `tasks/main.yml`.  Molecule separates these into distinct
+   lifecycle phases (`converge` vs `verify`).  For each migrated scenario:
+   - Open `roles/content/tasks/main.yml` (and any included task files).
+   - Identify assertion tasks: `assert`, `fail` with `when`, `stat` + register + assert,
+     check-mode-only tasks, and any `block:` sections whose sole purpose is validation.
+   - Move those tasks into a new `verify.yml` playbook at the scenario root.  This lets
+     maintainers re-run `molecule verify -s <target>` without re-converging — faster
+     iteration and proper alignment with Molecule's lifecycle.
+   - If a target's tasks are tightly interleaved (assert after every action), use judgment:
+     quick inline sanity checks can stay in converge, but the final state validation should
+     be in verify.
+
+4. Confirm shared inventory (`ansible_connection: local` on localhost) matches how the old
+   targets ran.  Add scenario-local inventory only when a target needs something different.
+
+5. Inspect `roles/content/` for ansible-test-only files (`aliases`, `runme.sh`, setup deps).
+   Remove or document anything Molecule will not honor.
+
+6. From the collection root, run `molecule test -s <target>` (or `molecule test --all`).
+   Fix playbook/role path issues first if converge fails to find role `content`.
+
+7. Update CI/tox so integration for migrated targets invokes Molecule, not
+   `ansible-test integration`.
+
+8. Clean empty `tests/integration/targets/` dirs; note remaining script-shaped targets that
+   were skipped.
+
+9. Summarize what changed, what still needs human platform/CI decisions, and any scenarios
+   that failed verification.

--- a/src/ansible_creator/resources/common/molecule_migrate/config.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/config.yml
@@ -1,0 +1,12 @@
+---
+# Shared ansible-native config for migrated scenarios.
+# ADE/tox installs the collection; prerun would fight that.
+prerun: false
+ansible:
+  executor:
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_SCENARIO_DIRECTORY}/../inventory.yml
+scenario:
+  test_sequence:
+    - converge

--- a/src/ansible_creator/resources/common/molecule_migrate/config.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/config.yml
@@ -10,3 +10,4 @@ ansible:
 scenario:
   test_sequence:
     - converge
+shared_state: true

--- a/src/ansible_creator/resources/common/molecule_migrate/config.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/config.yml
@@ -10,4 +10,5 @@ ansible:
 scenario:
   test_sequence:
     - converge
+    - verify
 shared_state: true

--- a/src/ansible_creator/resources/common/molecule_migrate/converge.yml.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/converge.yml.j2
@@ -1,0 +1,9 @@
+---
+# Purpose: run the migrated ansible-test integration target as a Molecule scenario.
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include migrated integration target
+      ansible.builtin.include_role:
+        name: content

--- a/src/ansible_creator/resources/common/molecule_migrate/default_molecule.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/default_molecule.yml
@@ -1,0 +1,10 @@
+---
+# Lifecycle manager for shared-state testing.
+# The default scenario owns create/destroy for all scenarios.
+# Add create.yml / destroy.yml / prepare.yml here when migrated targets
+# need shared infrastructure or setup roles.
+# See: https://docs.ansible.com/projects/molecule/getting-started-collections/
+scenario:
+  test_sequence:
+    - create
+    - destroy

--- a/src/ansible_creator/resources/common/molecule_migrate/inventory.yml
+++ b/src/ansible_creator/resources/common/molecule_migrate/inventory.yml
@@ -1,0 +1,6 @@
+---
+# Shared inventory for ansible-native migrated scenarios (localhost / connection local).
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/src/ansible_creator/resources/common/molecule_migrate/molecule.yml.j2
+++ b/src/ansible_creator/resources/common/molecule_migrate/molecule.yml.j2
@@ -1,0 +1,4 @@
+---
+# Migrated from tests/integration/targets/{{ target_name }}
+# Shared ansible-native config + inventory live in extensions/molecule/
+# (../config.yml, ../inventory.yml). Override here only when needed.

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 
 from importlib import resources as impl_resources
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
 
 RESOURCE_PACKAGE = "ansible_creator.resources.common.molecule_migrate"
 TASK_MAIN_NAMES = ("tasks/main.yml", "tasks/main.yaml")
+META_MAIN_NAMES = ("meta/main.yml", "meta/main.yaml")
+_ROLE_REF_RE = re.compile(r"role:\s*(\S+)")
 
 
 class Migrate:
@@ -136,7 +139,8 @@ class Migrate:
             msg = "No role-shaped integration targets were migrated."
             raise CreatorError(msg)
 
-        self._write_guidance_artifacts(migrated)
+        dep_map = self._scan_cross_dependencies(migrated)
+        self._write_guidance_artifacts(migrated, dep_map)
         self._ensure_shared_config()
         action = "copied" if self._keep_targets else "moved"
         self.output.note(
@@ -149,6 +153,14 @@ class Migrate:
         )
         if skipped:
             self.output.warning(msg=f"Skipped non-role targets: {', '.join(skipped)}")
+        if dep_map:
+            self.output.warning(
+                msg=(
+                    "Cross-target role dependencies detected. These require human or "
+                    "agent analysis to map into Molecule's shared-state lifecycle model. "
+                    "See MIGRATE_NEXT_STEPS.md for details."
+                ),
+            )
 
     @staticmethod
     def _is_role_shaped(target_dir: Path) -> bool:
@@ -236,24 +248,86 @@ class Migrate:
         template = (self._resource_root / filename).read_text(encoding="utf-8")
         return self.templar.render_from_content(template=template, data=data)
 
-    def _write_guidance_artifacts(self, migrated: list[str]) -> None:
+    def _scan_cross_dependencies(
+        self,
+        migrated: list[str],
+    ) -> dict[str, list[str]]:
+        """Scan migrated scenarios for cross-target role dependencies.
+
+        Looks at ``meta/main.yml`` in each migrated target's content role
+        for ``role:`` references that name other targets.  These cannot be
+        resolved automatically — they require human or agent analysis to
+        map into Molecule's shared-state lifecycle.
+
+        Args:
+            migrated: Names of targets that were migrated.
+
+        Returns:
+            Mapping of target name to list of referenced role names found
+            in its ``meta/main.yml``.  Empty when no cross-refs detected.
+        """
+        molecule_root = self._collection_path / "extensions" / "molecule"
+        migrated_set = set(migrated)
+        dep_map: dict[str, list[str]] = {}
+
+        for name in migrated:
+            content_dir = molecule_root / name / "roles" / "content"
+            for meta_name in META_MAIN_NAMES:
+                meta_file = content_dir / meta_name
+                if not meta_file.is_file():
+                    continue
+                text = meta_file.read_text(encoding="utf-8")
+                refs = [
+                    m.group(1)
+                    for m in _ROLE_REF_RE.finditer(text)
+                    if m.group(1) in migrated_set and m.group(1) != name
+                ]
+                if refs:
+                    dep_map[name] = refs
+                    self.output.warning(
+                        msg=(
+                            f"Target {name!r} references role(s) {refs} via meta/main.yml. "
+                            "These cross-target dependencies need analysis — see "
+                            "MIGRATE_NEXT_STEPS.md and the molecule-migrate-finalize skill."
+                        ),
+                    )
+        return dep_map
+
+    def _write_guidance_artifacts(
+        self,
+        migrated: list[str],
+        dep_map: dict[str, list[str]],
+    ) -> None:
         """Write next-steps checklist and agent skill into the collection.
 
         Args:
             migrated: Names of targets migrated in this run.
+            dep_map: Cross-target dependency map from _scan_cross_dependencies.
         """
         molecule_root = self._collection_path / "extensions" / "molecule"
         molecule_root.mkdir(parents=True, exist_ok=True)
 
         next_steps = molecule_root / "MIGRATE_NEXT_STEPS.md"
+        dep_lines = ""
+        if dep_map:
+            dep_lines = "\n".join(
+                f"- **{target}** depends on: {', '.join(deps)}"
+                for target, deps in sorted(dep_map.items())
+            )
         template_data = TemplateData(
             scenario_name=", ".join(migrated),
             target_name=", ".join(migrated),
+            cross_dependencies=dep_lines,
         )
-        next_steps.write_text(
-            self._render_template("MIGRATE_NEXT_STEPS.md.j2", template_data),
-            encoding="utf-8",
-        )
+        new_content = self._render_template("MIGRATE_NEXT_STEPS.md.j2", template_data)
+        if not next_steps.exists():
+            next_steps.write_text(new_content, encoding="utf-8")
+        elif self._no_overwrite:
+            self.output.warning(
+                msg=f"Skipped updating {next_steps} because --no-overwrite was set.",
+            )
+        else:
+            next_steps.write_text(new_content, encoding="utf-8")
 
         skill_dest = (
             self._collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
@@ -269,7 +343,7 @@ class Migrate:
                 skill_dest.write_text(skill_content, encoding="utf-8")
 
     def _ensure_shared_config(self) -> None:
-        """Write shared ansible-native config + inventory once if missing."""
+        """Write shared config, inventory, and default scenario if missing."""
         molecule_root = self._collection_path / "extensions" / "molecule"
         molecule_root.mkdir(parents=True, exist_ok=True)
         for filename in ("config.yml", "inventory.yml"):
@@ -278,5 +352,13 @@ class Migrate:
                 continue
             dest.write_text(
                 (self._resource_root / filename).read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+        default_dir = molecule_root / "default"
+        default_mol = default_dir / "molecule.yml"
+        if not default_mol.exists():
+            default_dir.mkdir(parents=True, exist_ok=True)
+            default_mol.write_text(
+                (self._resource_root / "default_molecule.yml").read_text(encoding="utf-8"),
                 encoding="utf-8",
             )

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -139,6 +139,19 @@ class Migrate:
             msg = "No role-shaped integration targets were migrated."
             raise CreatorError(msg)
 
+        self._finalize_migration(migrated, skipped)
+
+    def _finalize_migration(
+        self,
+        migrated: list[str],
+        skipped: list[str],
+    ) -> None:
+        """Generate guidance artifacts and report migration results.
+
+        Args:
+            migrated: Names of targets successfully migrated.
+            skipped: Names of targets that were skipped.
+        """
         dep_map = self._scan_cross_dependencies(migrated)
         self._write_guidance_artifacts(migrated, dep_map)
         self._ensure_shared_config()
@@ -291,6 +304,7 @@ class Migrate:
                             "MIGRATE_NEXT_STEPS.md and the molecule-migrate-finalize skill."
                         ),
                     )
+                    break
         return dep_map
 
     def _write_guidance_artifacts(

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import shutil
 
 from importlib import resources as impl_resources
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ansible_creator.exceptions import CreatorError
@@ -15,6 +14,8 @@ from ansible_creator.utils import ask_yes_no, expand_path
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ansible_creator.config import Config
     from ansible_creator.output import Output
 
@@ -45,7 +46,11 @@ class Migrate:
         self._resource_root = impl_resources.files(RESOURCE_PACKAGE)
 
     def run(self) -> None:
-        """Start the migration."""
+        """Start the migration.
+
+        Raises:
+            CreatorError: If the migrate type is unsupported or migration fails.
+        """
         if self._migrate_type != "molecule":
             msg = f"Unsupported migrate type: {self._migrate_type!r}. Choose from: molecule"
             raise CreatorError(msg)
@@ -85,7 +90,11 @@ class Migrate:
             raise CreatorError(msg)
 
     def _migrate_molecule(self) -> None:
-        """Migrate ansible-test integration targets into Molecule scenarios."""
+        """Migrate ansible-test integration targets into Molecule scenarios.
+
+        Raises:
+            CreatorError: If arguments are invalid or no role-shaped targets migrate.
+        """
         if self._migrate_all and self._target_name:
             msg = "Specify either a target name or --all, not both."
             raise CreatorError(msg)
@@ -247,11 +256,7 @@ class Migrate:
         )
 
         skill_dest = (
-            self._collection_path
-            / ".agents"
-            / "skills"
-            / "molecule-migrate-finalize"
-            / "SKILL.md"
+            self._collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
         )
         skill_dest.parent.mkdir(parents=True, exist_ok=True)
         skill_content = (self._resource_root / "SKILL.md").read_text(encoding="utf-8")

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -120,6 +120,9 @@ class Migrate:
 
         for name in candidates:
             source = targets_dir / name
+            if not source.resolve().is_relative_to(targets_dir.resolve()):
+                msg = f"Target name {name!r} resolves outside {targets_dir}."
+                raise CreatorError(msg)
             if not source.is_dir():
                 msg = f"Integration target not found: {source}"
                 raise CreatorError(msg)

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -1,0 +1,277 @@
+"""Definitions for ansible-creator migrate action."""
+
+from __future__ import annotations
+
+import shutil
+
+from importlib import resources as impl_resources
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ansible_creator.exceptions import CreatorError
+from ansible_creator.templar import Templar
+from ansible_creator.types import TemplateData
+from ansible_creator.utils import ask_yes_no, expand_path
+
+
+if TYPE_CHECKING:
+    from ansible_creator.config import Config
+    from ansible_creator.output import Output
+
+RESOURCE_PACKAGE = "ansible_creator.resources.common.molecule_migrate"
+TASK_MAIN_NAMES = ("tasks/main.yml", "tasks/main.yaml")
+
+
+class Migrate:
+    """Class to handle the migrate subcommand."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize the migrate action.
+
+        Args:
+            config: App configuration object.
+        """
+        self._migrate_type: str = config.migrate_type
+        self._target_name: str = config.target_name
+        self._migrate_all: bool = config.migrate_all
+        self._keep_targets: bool = config.keep_targets
+        self._collection_path: Path = expand_path(str(config.path))
+        self._force = config.force
+        self._overwrite = config.overwrite
+        self._no_overwrite = config.no_overwrite
+        self._skip_collection_check = config.skip_collection_check
+        self.output: Output = config.output
+        self.templar = Templar()
+        self._resource_root = impl_resources.files(RESOURCE_PACKAGE)
+
+    def run(self) -> None:
+        """Start the migration."""
+        if self._migrate_type != "molecule":
+            msg = f"Unsupported migrate type: {self._migrate_type!r}. Choose from: molecule"
+            raise CreatorError(msg)
+
+        self._check_path_exists()
+        self._check_collection_path()
+        self._migrate_molecule()
+
+    def _check_path_exists(self) -> None:
+        """Validate the provided collection path.
+
+        Raises:
+            CreatorError: If the path does not exist.
+        """
+        if not self._collection_path.exists():
+            msg = (
+                f"The path {self._collection_path} does not exist. "
+                "Please provide an existing directory."
+            )
+            raise CreatorError(msg)
+
+    def _check_collection_path(self) -> None:
+        """Validate that the path is an Ansible collection.
+
+        Raises:
+            CreatorError: If the path is not a collection path.
+        """
+        if self._skip_collection_check:
+            return
+
+        galaxy_file_path = self._collection_path / "galaxy.yml"
+        if not galaxy_file_path.is_file():
+            msg = (
+                f"The path {self._collection_path} is not a valid Ansible collection path. "
+                "Please provide the root path of a valid ansible collection."
+            )
+            raise CreatorError(msg)
+
+    def _migrate_molecule(self) -> None:
+        """Migrate ansible-test integration targets into Molecule scenarios."""
+        if self._migrate_all and self._target_name:
+            msg = "Specify either a target name or --all, not both."
+            raise CreatorError(msg)
+        if not self._migrate_all and not self._target_name:
+            msg = "Specify a target name or --all."
+            raise CreatorError(msg)
+
+        targets_dir = self._collection_path / "tests" / "integration" / "targets"
+        if not targets_dir.is_dir():
+            msg = f"No integration targets directory found at {targets_dir}."
+            raise CreatorError(msg)
+
+        if self._migrate_all:
+            candidates = sorted(path.name for path in targets_dir.iterdir() if path.is_dir())
+        else:
+            candidates = [self._target_name]
+
+        migrated: list[str] = []
+        skipped: list[str] = []
+
+        for name in candidates:
+            source = targets_dir / name
+            if not source.is_dir():
+                msg = f"Integration target not found: {source}"
+                raise CreatorError(msg)
+            if not self._is_role_shaped(source):
+                self.output.warning(
+                    msg=(
+                        f"Skipping {name!r}: not a role-shaped target "
+                        f"(expected tasks/main.yml or tasks/main.yaml)."
+                    ),
+                )
+                skipped.append(name)
+                continue
+            self._migrate_one_target(name=name, source=source)
+            migrated.append(name)
+
+        if not migrated:
+            msg = "No role-shaped integration targets were migrated."
+            raise CreatorError(msg)
+
+        self._write_guidance_artifacts(migrated)
+        self._ensure_shared_config()
+        action = "copied" if self._keep_targets else "moved"
+        self.output.note(
+            msg=(
+                f"{action.capitalize()} {len(migrated)} integration target(s) into "
+                f"extensions/molecule/: {', '.join(migrated)}. "
+                "Next: open extensions/molecule/MIGRATE_NEXT_STEPS.md or invoke the "
+                "molecule-migrate-finalize agent skill."
+            ),
+        )
+        if skipped:
+            self.output.warning(msg=f"Skipped non-role targets: {', '.join(skipped)}")
+
+    @staticmethod
+    def _is_role_shaped(target_dir: Path) -> bool:
+        """Return True when the target looks like an Ansible role.
+
+        Args:
+            target_dir: Path to an integration target directory.
+
+        Returns:
+            Whether the target has tasks/main.yml or tasks/main.yaml.
+        """
+        return any((target_dir / relative).is_file() for relative in TASK_MAIN_NAMES)
+
+    def _migrate_one_target(self, name: str, source: Path) -> None:
+        """Migrate a single integration target into a Molecule scenario.
+
+        Args:
+            name: Target / scenario name.
+            source: Path to tests/integration/targets/<name>.
+
+        Raises:
+            CreatorError: On overwrite conflicts when not permitted.
+        """
+        scenario_dir = self._collection_path / "extensions" / "molecule" / name
+        content_dir = scenario_dir / "roles" / "content"
+        molecule_yml = scenario_dir / "molecule.yml"
+        converge_yml = scenario_dir / "converge.yml"
+
+        conflicts = [
+            path
+            for path in (scenario_dir, content_dir, molecule_yml, converge_yml)
+            if path.exists()
+        ]
+        if conflicts:
+            conflict_list = ", ".join(str(path) for path in conflicts)
+            if self._no_overwrite:
+                msg = (
+                    f"The following path(s) already exist and --no-overwrite was set: "
+                    f"{conflict_list}"
+                )
+                raise CreatorError(msg)
+            if not (self._force or self._overwrite):
+                question = (
+                    f"Path(s) already exist for scenario {name!r}: {conflict_list}. Overwrite?"
+                )
+                if not ask_yes_no(question):
+                    msg = (
+                        f"The program aborted due to existing content for scenario {name!r}. "
+                        "Re-run with --overwrite to continue."
+                    )
+                    raise CreatorError(msg)
+
+            if scenario_dir.exists():
+                shutil.rmtree(scenario_dir)
+
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        content_dir.parent.mkdir(parents=True, exist_ok=True)
+        template_data = TemplateData(scenario_name=name, target_name=name)
+        molecule_yml.write_text(
+            self._render_template("molecule.yml.j2", template_data),
+            encoding="utf-8",
+        )
+        converge_yml.write_text(
+            self._render_template("converge.yml.j2", template_data),
+            encoding="utf-8",
+        )
+
+        if self._keep_targets:
+            shutil.copytree(source, content_dir)
+        else:
+            shutil.move(str(source), str(content_dir))
+
+        self.output.debug(msg=f"Migrated integration target {name!r} to {scenario_dir}")
+
+    def _render_template(self, filename: str, data: TemplateData) -> str:
+        """Load and render a migrate template.
+
+        Args:
+            filename: Template filename under the molecule_migrate resource package.
+            data: Template data.
+
+        Returns:
+            Rendered template content.
+        """
+        template = (self._resource_root / filename).read_text(encoding="utf-8")
+        return self.templar.render_from_content(template=template, data=data)
+
+    def _write_guidance_artifacts(self, migrated: list[str]) -> None:
+        """Write next-steps checklist and agent skill into the collection.
+
+        Args:
+            migrated: Names of targets migrated in this run.
+        """
+        molecule_root = self._collection_path / "extensions" / "molecule"
+        molecule_root.mkdir(parents=True, exist_ok=True)
+
+        next_steps = molecule_root / "MIGRATE_NEXT_STEPS.md"
+        template_data = TemplateData(
+            scenario_name=", ".join(migrated),
+            target_name=", ".join(migrated),
+        )
+        next_steps.write_text(
+            self._render_template("MIGRATE_NEXT_STEPS.md.j2", template_data),
+            encoding="utf-8",
+        )
+
+        skill_dest = (
+            self._collection_path
+            / ".agents"
+            / "skills"
+            / "molecule-migrate-finalize"
+            / "SKILL.md"
+        )
+        skill_dest.parent.mkdir(parents=True, exist_ok=True)
+        skill_content = (self._resource_root / "SKILL.md").read_text(encoding="utf-8")
+        if not skill_dest.exists() or skill_dest.read_text(encoding="utf-8") != skill_content:
+            if skill_dest.exists() and self._no_overwrite:
+                self.output.warning(
+                    msg=f"Skipped updating {skill_dest} because --no-overwrite was set.",
+                )
+            else:
+                skill_dest.write_text(skill_content, encoding="utf-8")
+
+    def _ensure_shared_config(self) -> None:
+        """Write shared ansible-native config + inventory once if missing."""
+        molecule_root = self._collection_path / "extensions" / "molecule"
+        molecule_root.mkdir(parents=True, exist_ok=True)
+        for filename in ("config.yml", "inventory.yml"):
+            dest = molecule_root / filename
+            if dest.exists():
+                continue
+            dest.write_text(
+                (self._resource_root / filename).read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )

--- a/src/ansible_creator/subcommands/migrate.py
+++ b/src/ansible_creator/subcommands/migrate.py
@@ -192,8 +192,8 @@ class Migrate:
                     )
                     raise CreatorError(msg)
 
-            if scenario_dir.exists():
-                shutil.rmtree(scenario_dir)
+            # Conflicts imply scenario_dir already exists (children cannot exist without it).
+            shutil.rmtree(scenario_dir)
 
         scenario_dir.mkdir(parents=True, exist_ok=True)
         content_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -802,12 +802,16 @@ class TemplateData:
         ee_scm_token_vars: Pre-computed list of token env var names from scm_servers.
         ee_file_name: Name of the EE definition file.
         scm_provider: SCM provider for documentation templates (github or gitlab).
+        scenario_name: Molecule scenario name (migrate molecule).
+        target_name: Integration target name (migrate molecule).
     """
 
     resource_type: str = ""
     plugin_type: str = ""
     plugin_name: str = ""
     role_name: str = ""
+    scenario_name: str = ""
+    target_name: str = ""
     additions: dict[str, dict[str, dict[str, str | bool]]] = field(default_factory=dict)
     collection_name: str = ""
     creator_version: str = ""

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -767,6 +767,8 @@ class TemplateData:
         plugin_type: The type of plugin to be scaffolded.
         plugin_name: The name of the plugin to be scaffolded.
         role_name: The name of the role to be scaffolded.
+        scenario_name: Molecule scenario name (migrate molecule).
+        target_name: Integration target name (migrate molecule).
         additions: A dictionary containing additional data to add to the gitignore.
         collection_name: The name of the collection.
         creator_version: The version of the creator.
@@ -802,8 +804,6 @@ class TemplateData:
         ee_scm_token_vars: Pre-computed list of token env var names from scm_servers.
         ee_file_name: Name of the EE definition file.
         scm_provider: SCM provider for documentation templates (github or gitlab).
-        scenario_name: Molecule scenario name (migrate molecule).
-        target_name: Integration target name (migrate molecule).
     """
 
     resource_type: str = ""

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -769,6 +769,7 @@ class TemplateData:
         role_name: The name of the role to be scaffolded.
         scenario_name: Molecule scenario name (migrate molecule).
         target_name: Integration target name (migrate molecule).
+        cross_dependencies: Pre-rendered cross-target dependency lines for MIGRATE_NEXT_STEPS.
         additions: A dictionary containing additional data to add to the gitignore.
         collection_name: The name of the collection.
         creator_version: The version of the creator.
@@ -812,6 +813,7 @@ class TemplateData:
     role_name: str = ""
     scenario_name: str = ""
     target_name: str = ""
+    cross_dependencies: str = ""
     additions: dict[str, dict[str, dict[str, str | bool]]] = field(default_factory=dict)
     collection_name: str = ""
     creator_version: str = ""

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -1,0 +1,41 @@
+"""Integration tests for ansible-creator migrate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.defaults import CREATOR_BIN
+
+
+if TYPE_CHECKING:
+    from tests.conftest import CliRunCallable
+
+
+def test_migrate_molecule_cli(cli: CliRunCallable, tmp_path: Path) -> None:
+    """Migrate a role-shaped integration target via the CLI."""
+    collection = tmp_path / "ns" / "col"
+    targets = collection / "tests" / "integration" / "targets" / "sample"
+    tasks = targets / "tasks"
+    tasks.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 0.1.0\n")
+    (tasks / "main.yml").write_text("---\n- ansible.builtin.debug:\n    msg: ok\n")
+
+    result = cli(
+        f"{CREATOR_BIN} migrate molecule sample --path {collection}",
+        env={"NO_COLOR": "1"},
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Moved" in result.stdout or "moved" in result.stdout.lower()
+
+    scenario = collection / "extensions" / "molecule" / "sample"
+    assert (scenario / "molecule.yml").is_file()
+    assert (scenario / "converge.yml").is_file()
+    assert (scenario / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert not targets.exists()
+    assert (collection / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md").is_file()
+    assert (collection / "extensions" / "molecule" / "config.yml").is_file()
+    assert (collection / "extensions" / "molecule" / "inventory.yml").is_file()
+    assert (collection / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md").is_file()
+    assert "platforms:" not in (scenario / "molecule.yml").read_text()
+    assert "name: content" in (scenario / "converge.yml").read_text()

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tests.defaults import CREATOR_BIN
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tests.conftest import CliRunCallable
 
 
 def test_migrate_molecule_cli(cli: CliRunCallable, tmp_path: Path) -> None:
-    """Migrate a role-shaped integration target via the CLI."""
+    """Migrate a role-shaped integration target via the CLI.
+
+    Args:
+        cli: cli_run function.
+        tmp_path: Temporary directory path.
+    """
     collection = tmp_path / "ns" / "col"
     targets = collection / "tests" / "integration" / "targets" / "sample"
     tasks = targets / "tasks"
@@ -42,7 +48,12 @@ def test_migrate_molecule_cli(cli: CliRunCallable, tmp_path: Path) -> None:
 
 
 def test_migrate_molecule_cli_all_and_keep(cli: CliRunCallable, tmp_path: Path) -> None:
-    """Migrate all role-shaped targets while keeping ansible-test trees."""
+    """Migrate all role-shaped targets while keeping ansible-test trees.
+
+    Args:
+        cli: cli_run function.
+        tmp_path: Temporary directory path.
+    """
     collection = tmp_path / "ns" / "col"
     targets = collection / "tests" / "integration" / "targets"
     for name in ("one", "two"):

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -39,3 +39,31 @@ def test_migrate_molecule_cli(cli: CliRunCallable, tmp_path: Path) -> None:
     assert (collection / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md").is_file()
     assert "platforms:" not in (scenario / "molecule.yml").read_text()
     assert "name: content" in (scenario / "converge.yml").read_text()
+
+
+def test_migrate_molecule_cli_all_and_keep(cli: CliRunCallable, tmp_path: Path) -> None:
+    """Migrate all role-shaped targets while keeping ansible-test trees."""
+    collection = tmp_path / "ns" / "col"
+    targets = collection / "tests" / "integration" / "targets"
+    for name in ("one", "two"):
+        tasks = targets / name / "tasks"
+        tasks.mkdir(parents=True)
+        (tasks / "main.yml").write_text("---\n- ansible.builtin.debug:\n    msg: ok\n")
+    scripty = targets / "scripty"
+    scripty.mkdir(parents=True)
+    (scripty / "runme.sh").write_text("#!/bin/sh\necho hi\n")
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 0.1.0\n")
+
+    result = cli(
+        f"{CREATOR_BIN} migrate molecule --all --keep-targets --path {collection}",
+        env={"NO_COLOR": "1"},
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (targets / "one").is_dir()
+    assert (targets / "two").is_dir()
+    assert (targets / "scripty").is_dir()
+    molecule_root = collection / "extensions" / "molecule"
+    assert (molecule_root / "one" / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert (molecule_root / "two" / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert not (molecule_root / "scripty").exists()
+    assert "ansible_connection: local" in (molecule_root / "inventory.yml").read_text()

--- a/tests/integration/test_no_input.py
+++ b/tests/integration/test_no_input.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
         pytest.param("add plugin --help", "", id="add-plugin-help"),
         pytest.param("init", "Missing required argument 'project-type'.", id="init"),
         pytest.param("init --help", "", id="init-help"),
+        pytest.param("migrate", "Missing required argument 'migrate-type'.", id="migrate"),
+        pytest.param("migrate --help", "", id="migrate-help"),
     ),
 )
 def test_run_no_input(cli: CliRunCallable, args: str, error_msg: str) -> None:

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -205,6 +205,60 @@ def test_configuration_class(output: Output) -> None:
                 "exclude": [],
             },
         ),
+        (
+            [
+                "ansible-creator",
+                "migrate",
+                "molecule",
+                "alpha",
+                "--path=/tmp/col",
+                "--keep-targets",
+                "--overwrite",
+                "--lf=test.log",
+            ],
+            {
+                "subcommand": "migrate",
+                "migrate_type": "molecule",
+                "target_name": "alpha",
+                "migrate_all": False,
+                "keep_targets": True,
+                "path": "/tmp/col",
+                "no_overwrite": False,
+                "overwrite": True,
+                "json": False,
+                "log_append": "true",
+                "log_file": "test.log",
+                "log_level": "notset",
+                "no_ansi": False,
+                "verbose": 0,
+            },
+        ),
+        (
+            [
+                "ansible-creator",
+                "migrate",
+                "molecule",
+                "--all",
+                "--path=/tmp/col",
+                "--lf=test.log",
+            ],
+            {
+                "subcommand": "migrate",
+                "migrate_type": "molecule",
+                "target_name": "",
+                "migrate_all": True,
+                "keep_targets": False,
+                "path": "/tmp/col",
+                "no_overwrite": False,
+                "overwrite": False,
+                "json": False,
+                "log_append": "true",
+                "log_file": "test.log",
+                "log_level": "notset",
+                "no_ansi": False,
+                "verbose": 0,
+            },
+        ),
     ),
 )
 def test_cli_parser(
@@ -223,6 +277,14 @@ def test_cli_parser(
     monkeypatch.setattr("sys.argv", sysargs)
     parsed_args = Cli().args
     assert parsed_args == expected
+
+
+def test_cli_migrate_missing_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Require migrate-type when invoking migrate with no subcommand."""
+    monkeypatch.setattr("sys.argv", ["ansible-creator", "migrate"])
+    cli = Cli()
+    assert cli.exit_code != 0
+    assert any("migrate-type" in msg.message for msg in cli.pending_logs)
 
 
 def test_missing_j2(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/units/test_basic.py
+++ b/tests/units/test_basic.py
@@ -211,7 +211,7 @@ def test_configuration_class(output: Output) -> None:
                 "migrate",
                 "molecule",
                 "alpha",
-                "--path=/tmp/col",
+                "--path=/test/col",
                 "--keep-targets",
                 "--overwrite",
                 "--lf=test.log",
@@ -222,7 +222,7 @@ def test_configuration_class(output: Output) -> None:
                 "target_name": "alpha",
                 "migrate_all": False,
                 "keep_targets": True,
-                "path": "/tmp/col",
+                "path": "/test/col",
                 "no_overwrite": False,
                 "overwrite": True,
                 "json": False,
@@ -239,7 +239,7 @@ def test_configuration_class(output: Output) -> None:
                 "migrate",
                 "molecule",
                 "--all",
-                "--path=/tmp/col",
+                "--path=/test/col",
                 "--lf=test.log",
             ],
             {
@@ -248,7 +248,7 @@ def test_configuration_class(output: Output) -> None:
                 "target_name": "",
                 "migrate_all": True,
                 "keep_targets": False,
-                "path": "/tmp/col",
+                "path": "/test/col",
                 "no_overwrite": False,
                 "overwrite": False,
                 "json": False,
@@ -280,7 +280,11 @@ def test_cli_parser(
 
 
 def test_cli_migrate_missing_type(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Require migrate-type when invoking migrate with no subcommand."""
+    """Require migrate-type when invoking migrate with no subcommand.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     monkeypatch.setattr("sys.argv", ["ansible-creator", "migrate"])
     cli = Cli()
     assert cli.exit_code != 0

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -1,0 +1,178 @@
+# cspell: ignore dcmp
+"""Unit tests for ansible-creator migrate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ansible_creator.config import Config
+from ansible_creator.exceptions import CreatorError
+from ansible_creator.subcommands.migrate import Migrate
+
+
+if TYPE_CHECKING:
+    from ansible_creator.output import Output
+
+
+def _write_role_target(targets_dir: Path, name: str, *, main_name: str = "main.yml") -> Path:
+    target = targets_dir / name
+    tasks = target / "tasks"
+    tasks.mkdir(parents=True)
+    (tasks / main_name).write_text("---\n- name: Ping\n  ansible.builtin.debug:\n    msg: hi\n")
+    return target
+
+
+def _seed_collection(tmp_path: Path) -> Path:
+    collection = tmp_path / "ns" / "col"
+    collection.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    _write_role_target(targets, "alpha")
+    _write_role_target(targets, "beta", main_name="main.yaml")
+    script_only = targets / "scripty"
+    script_only.mkdir()
+    (script_only / "runme.sh").write_text("#!/bin/sh\necho hi\n")
+    return collection
+
+
+@pytest.fixture(name="collection_path")
+def fixture_collection_path(tmp_path: Path) -> Path:
+    return _seed_collection(tmp_path)
+
+
+def _migrate_config(
+    output: Output,
+    path: Path,
+    *,
+    target_name: str = "",
+    migrate_all: bool = False,
+    keep_targets: bool = False,
+    overwrite: bool = False,
+    no_overwrite: bool = False,
+) -> Config:
+    return Config(
+        creator_version="0.0.1",
+        output=output,
+        subcommand="migrate",
+        migrate_type="molecule",
+        target_name=target_name,
+        migrate_all=migrate_all,
+        keep_targets=keep_targets,
+        path=str(path),
+        overwrite=overwrite,
+        no_overwrite=no_overwrite,
+    )
+
+
+def test_migrate_single_target_moves(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha")).run()
+
+    scenario = collection_path / "extensions" / "molecule" / "alpha"
+    assert (scenario / "molecule.yml").is_file()
+    assert (scenario / "converge.yml").is_file()
+    assert (scenario / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert not (collection_path / "tests" / "integration" / "targets" / "alpha").exists()
+    assert (collection_path / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md").is_file()
+    assert (
+        collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
+    ).is_file()
+    assert (collection_path / "extensions" / "molecule" / "config.yml").is_file()
+    assert (collection_path / "extensions" / "molecule" / "inventory.yml").is_file()
+    assert "prerun: false" in (
+        collection_path / "extensions" / "molecule" / "config.yml"
+    ).read_text()
+    assert "ansible_connection: local" in (
+        collection_path / "extensions" / "molecule" / "inventory.yml"
+    ).read_text()
+    molecule_yml = (scenario / "molecule.yml").read_text()
+    assert "platforms:" not in molecule_yml
+    assert "provisioner:" not in molecule_yml
+    converge = (scenario / "converge.yml").read_text()
+    assert "name: content" in converge
+    assert "playbook_dir" not in converge
+
+
+def test_migrate_all_skips_non_role(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, migrate_all=True)).run()
+
+    molecule_root = collection_path / "extensions" / "molecule"
+    assert (molecule_root / "alpha" / "roles" / "content" / "tasks" / "main.yml").is_file()
+    assert (molecule_root / "beta" / "roles" / "content" / "tasks" / "main.yaml").is_file()
+    assert not (molecule_root / "scripty").exists()
+    assert (collection_path / "tests" / "integration" / "targets" / "scripty").is_dir()
+
+
+def test_migrate_keep_targets(collection_path: Path, output: Output) -> None:
+    Migrate(
+        _migrate_config(output, collection_path, target_name="alpha", keep_targets=True),
+    ).run()
+
+    assert (collection_path / "tests" / "integration" / "targets" / "alpha").is_dir()
+    assert (
+        collection_path
+        / "extensions"
+        / "molecule"
+        / "alpha"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yml"
+    ).is_file()
+
+
+def test_migrate_requires_target_or_all(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="target name or --all"):
+        Migrate(_migrate_config(output, collection_path)).run()
+
+
+def test_migrate_rejects_target_and_all(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="not both"):
+        Migrate(
+            _migrate_config(output, collection_path, target_name="alpha", migrate_all=True),
+        ).run()
+
+
+def test_migrate_missing_target(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="not found"):
+        Migrate(_migrate_config(output, collection_path, target_name="missing")).run()
+
+
+def test_migrate_no_overwrite(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    with pytest.raises(CreatorError, match="--no-overwrite"):
+        Migrate(
+            _migrate_config(
+                output,
+                collection_path,
+                target_name="beta",
+                keep_targets=True,
+                no_overwrite=True,
+            ),
+        ).run()
+
+
+def test_migrate_overwrite(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    Migrate(
+        _migrate_config(
+            output,
+            collection_path,
+            target_name="beta",
+            keep_targets=True,
+            overwrite=True,
+        ),
+    ).run()
+    assert (
+        collection_path
+        / "extensions"
+        / "molecule"
+        / "beta"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yaml"
+    ).is_file()

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -14,10 +13,22 @@ from ansible_creator.subcommands.migrate import Migrate
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ansible_creator.output import Output
 
 
 def _write_role_target(targets_dir: Path, name: str, *, main_name: str = "main.yml") -> Path:
+    """Create a minimal role-shaped integration target.
+
+    Args:
+        targets_dir: Parent targets directory.
+        name: Target name.
+        main_name: Tasks main filename.
+
+    Returns:
+        Path to the created target directory.
+    """
     target = targets_dir / name
     tasks = target / "tasks"
     tasks.mkdir(parents=True)
@@ -26,6 +37,14 @@ def _write_role_target(targets_dir: Path, name: str, *, main_name: str = "main.y
 
 
 def _seed_collection(tmp_path: Path) -> Path:
+    """Seed a collection with role-shaped and script-only targets.
+
+    Args:
+        tmp_path: Temporary directory path.
+
+    Returns:
+        Path to the seeded collection root.
+    """
     collection = tmp_path / "ns" / "col"
     collection.mkdir(parents=True)
     (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
@@ -41,10 +60,18 @@ def _seed_collection(tmp_path: Path) -> Path:
 
 @pytest.fixture(name="collection_path")
 def fixture_collection_path(tmp_path: Path) -> Path:
+    """Provide a seeded collection path.
+
+    Args:
+        tmp_path: Temporary directory path.
+
+    Returns:
+        Path to the seeded collection root.
+    """
     return _seed_collection(tmp_path)
 
 
-def _migrate_config(
+def _migrate_config(  # noqa: PLR0913
     output: Output,
     path: Path,
     *,
@@ -57,6 +84,23 @@ def _migrate_config(
     migrate_type: str = "molecule",
     skip_collection_check: bool = False,
 ) -> Config:
+    """Build a migrate Config for tests.
+
+    Args:
+        output: Output class object.
+        path: Collection path.
+        target_name: Optional target name.
+        migrate_all: Whether to migrate all targets.
+        keep_targets: Whether to copy instead of move.
+        overwrite: Whether to overwrite existing scenarios.
+        no_overwrite: Whether to refuse overwrites.
+        force: Whether to force overwrite without prompting.
+        migrate_type: Migrate destination type.
+        skip_collection_check: Whether to skip galaxy.yml validation.
+
+    Returns:
+        Config instance for Migrate.
+    """
     return Config(
         creator_version="0.0.1",
         output=output,
@@ -74,6 +118,12 @@ def _migrate_config(
 
 
 def test_migrate_single_target_moves(collection_path: Path, output: Output) -> None:
+    """Move one target into an ansible-native scenario layout.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha")).run()
 
     scenario = collection_path / "extensions" / "molecule" / "alpha"
@@ -87,12 +137,13 @@ def test_migrate_single_target_moves(collection_path: Path, output: Output) -> N
     ).is_file()
     assert (collection_path / "extensions" / "molecule" / "config.yml").is_file()
     assert (collection_path / "extensions" / "molecule" / "inventory.yml").is_file()
-    assert "prerun: false" in (
-        collection_path / "extensions" / "molecule" / "config.yml"
-    ).read_text()
-    assert "ansible_connection: local" in (
-        collection_path / "extensions" / "molecule" / "inventory.yml"
-    ).read_text()
+    assert (
+        "prerun: false" in (collection_path / "extensions" / "molecule" / "config.yml").read_text()
+    )
+    assert (
+        "ansible_connection: local"
+        in (collection_path / "extensions" / "molecule" / "inventory.yml").read_text()
+    )
     molecule_yml = (scenario / "molecule.yml").read_text()
     assert "platforms:" not in molecule_yml
     assert "provisioner:" not in molecule_yml
@@ -102,6 +153,12 @@ def test_migrate_single_target_moves(collection_path: Path, output: Output) -> N
 
 
 def test_migrate_all_skips_non_role(collection_path: Path, output: Output) -> None:
+    """Migrate all role-shaped targets and skip script-only ones.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, migrate_all=True)).run()
 
     molecule_root = collection_path / "extensions" / "molecule"
@@ -112,6 +169,12 @@ def test_migrate_all_skips_non_role(collection_path: Path, output: Output) -> No
 
 
 def test_migrate_keep_targets(collection_path: Path, output: Output) -> None:
+    """Copy targets into scenarios when --keep-targets is set.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(
         _migrate_config(output, collection_path, target_name="alpha", keep_targets=True),
     ).run()
@@ -130,11 +193,23 @@ def test_migrate_keep_targets(collection_path: Path, output: Output) -> None:
 
 
 def test_migrate_requires_target_or_all(collection_path: Path, output: Output) -> None:
+    """Require either a target name or --all.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     with pytest.raises(CreatorError, match="target name or --all"):
         Migrate(_migrate_config(output, collection_path)).run()
 
 
 def test_migrate_rejects_target_and_all(collection_path: Path, output: Output) -> None:
+    """Reject specifying both a target name and --all.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     with pytest.raises(CreatorError, match="not both"):
         Migrate(
             _migrate_config(output, collection_path, target_name="alpha", migrate_all=True),
@@ -142,11 +217,23 @@ def test_migrate_rejects_target_and_all(collection_path: Path, output: Output) -
 
 
 def test_migrate_missing_target(collection_path: Path, output: Output) -> None:
+    """Fail when the named target does not exist.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     with pytest.raises(CreatorError, match="not found"):
         Migrate(_migrate_config(output, collection_path, target_name="missing")).run()
 
 
 def test_migrate_no_overwrite(collection_path: Path, output: Output) -> None:
+    """Fail when scenario paths exist and --no-overwrite is set.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
     with pytest.raises(CreatorError, match="--no-overwrite"):
         Migrate(
@@ -161,6 +248,12 @@ def test_migrate_no_overwrite(collection_path: Path, output: Output) -> None:
 
 
 def test_migrate_overwrite(collection_path: Path, output: Output) -> None:
+    """Overwrite an existing scenario when --overwrite is set.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
     Migrate(
         _migrate_config(
@@ -184,6 +277,12 @@ def test_migrate_overwrite(collection_path: Path, output: Output) -> None:
 
 
 def test_migrate_unsupported_type(collection_path: Path, output: Output) -> None:
+    """Reject unsupported migrate types.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     with pytest.raises(CreatorError, match="Unsupported migrate type"):
         Migrate(
             _migrate_config(output, collection_path, target_name="alpha", migrate_type="galaxy"),
@@ -191,12 +290,24 @@ def test_migrate_unsupported_type(collection_path: Path, output: Output) -> None
 
 
 def test_migrate_path_missing(tmp_path: Path, output: Output) -> None:
+    """Fail when the collection path does not exist.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
     missing = tmp_path / "does-not-exist"
     with pytest.raises(CreatorError, match="does not exist"):
         Migrate(_migrate_config(output, missing, target_name="alpha")).run()
 
 
 def test_migrate_not_a_collection(tmp_path: Path, output: Output) -> None:
+    """Fail when the path is not a collection root.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
     path = tmp_path / "not-a-collection"
     path.mkdir()
     with pytest.raises(CreatorError, match="not a valid Ansible collection"):
@@ -204,6 +315,12 @@ def test_migrate_not_a_collection(tmp_path: Path, output: Output) -> None:
 
 
 def test_migrate_skip_collection_check(tmp_path: Path, output: Output) -> None:
+    """Allow migration without galaxy.yml when skip_collection_check is set.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
     collection = tmp_path / "loose"
     targets = collection / "tests" / "integration" / "targets"
     targets.mkdir(parents=True)
@@ -218,11 +335,24 @@ def test_migrate_skip_collection_check(tmp_path: Path, output: Output) -> None:
         ),
     ).run()
     assert (
-        collection / "extensions" / "molecule" / "alpha" / "roles" / "content" / "tasks" / "main.yml"
+        collection
+        / "extensions"
+        / "molecule"
+        / "alpha"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yml"
     ).is_file()
 
 
 def test_migrate_missing_targets_dir(tmp_path: Path, output: Output) -> None:
+    """Fail when tests/integration/targets is missing.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
     collection = tmp_path / "ns" / "col"
     collection.mkdir(parents=True)
     (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
@@ -231,6 +361,12 @@ def test_migrate_missing_targets_dir(tmp_path: Path, output: Output) -> None:
 
 
 def test_migrate_all_none_role_shaped(tmp_path: Path, output: Output) -> None:
+    """Fail when --all finds no role-shaped targets.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
     collection = tmp_path / "ns" / "col"
     targets = collection / "tests" / "integration" / "targets"
     targets.mkdir(parents=True)
@@ -248,6 +384,13 @@ def test_migrate_prompt_declines_overwrite(
     output: Output,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Abort when the overwrite prompt is declined.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
     monkeypatch.setattr("builtins.input", lambda _: "n")
     with pytest.raises(CreatorError, match="aborted due to existing content"):
@@ -261,6 +404,13 @@ def test_migrate_prompt_accepts_overwrite(
     output: Output,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Overwrite when the overwrite prompt is accepted.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
     monkeypatch.setattr("builtins.input", lambda _: "y")
     Migrate(
@@ -279,6 +429,12 @@ def test_migrate_prompt_accepts_overwrite(
 
 
 def test_migrate_force_overwrite(collection_path: Path, output: Output) -> None:
+    """Overwrite without prompting when force is set.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
     Migrate(
         _migrate_config(
@@ -302,6 +458,12 @@ def test_migrate_force_overwrite(collection_path: Path, output: Output) -> None:
 
 
 def test_migrate_skips_rewriting_shared_config(collection_path: Path, output: Output) -> None:
+    """Leave existing shared config and inventory untouched on later runs.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
     config_path = collection_path / "extensions" / "molecule" / "config.yml"
     inventory_path = collection_path / "extensions" / "molecule" / "inventory.yml"
@@ -317,10 +479,14 @@ def test_migrate_skill_no_overwrite_keeps_custom(
     collection_path: Path,
     output: Output,
 ) -> None:
+    """Keep a customized skill file when --no-overwrite is set.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
-    skill = (
-        collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
-    )
+    skill = collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
     skill.write_text("# custom skill\n")
 
     Migrate(
@@ -336,10 +502,14 @@ def test_migrate_skill_no_overwrite_keeps_custom(
 
 
 def test_migrate_skill_unchanged_is_left_alone(collection_path: Path, output: Output) -> None:
+    """Do not rewrite an identical skill file on later migrations.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
     Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
-    skill = (
-        collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
-    )
+    skill = collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
     original = skill.read_text()
 
     Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -545,6 +545,56 @@ def test_migrate_detects_cross_dependencies(tmp_path: Path, output: Output) -> N
     assert "Cross-target role dependencies" in content
 
 
+def test_migrate_detects_cross_dependencies_yaml_ext(tmp_path: Path, output: Output) -> None:
+    """Detect cross-target role references in meta/main.yaml (alternate extension).
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
+    collection = tmp_path / "ns" / "col"
+    collection.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    _write_role_target(targets, "setup_net")
+    target_app = _write_role_target(targets, "router")
+    meta = target_app / "meta"
+    meta.mkdir()
+    (meta / "main.yaml").write_text("---\ndependencies:\n  - role: setup_net\n")
+
+    Migrate(_migrate_config(output, collection, migrate_all=True)).run()
+
+    next_steps = collection / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md"
+    content = next_steps.read_text()
+    assert "setup_net" in content
+    assert "Cross-target role dependencies" in content
+
+
+def test_migrate_meta_without_cross_refs(tmp_path: Path, output: Output) -> None:
+    """Meta file with only external (non-migrated) role refs produces no cross-dep section.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
+    collection = tmp_path / "ns" / "col"
+    collection.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    target = _write_role_target(targets, "my_role")
+    meta = target / "meta"
+    meta.mkdir()
+    (meta / "main.yml").write_text("---\ndependencies:\n  - role: some_external_role\n")
+
+    Migrate(_migrate_config(output, collection, target_name="my_role")).run()
+
+    next_steps = collection / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md"
+    content = next_steps.read_text()
+    assert "Cross-target role dependencies" not in content
+
+
 def test_migrate_no_cross_dependencies(collection_path: Path, output: Output) -> None:
     """No cross-dependency section when targets are independent.
 

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -137,13 +137,16 @@ def test_migrate_single_target_moves(collection_path: Path, output: Output) -> N
     ).is_file()
     assert (collection_path / "extensions" / "molecule" / "config.yml").is_file()
     assert (collection_path / "extensions" / "molecule" / "inventory.yml").is_file()
-    assert (
-        "prerun: false" in (collection_path / "extensions" / "molecule" / "config.yml").read_text()
-    )
+    config_text = (collection_path / "extensions" / "molecule" / "config.yml").read_text()
+    assert "prerun: false" in config_text
+    assert "shared_state: true" in config_text
     assert (
         "ansible_connection: local"
         in (collection_path / "extensions" / "molecule" / "inventory.yml").read_text()
     )
+    default_mol = collection_path / "extensions" / "molecule" / "default" / "molecule.yml"
+    assert default_mol.is_file()
+    assert "create" in default_mol.read_text()
     molecule_yml = (scenario / "molecule.yml").read_text()
     assert "platforms:" not in molecule_yml
     assert "provisioner:" not in molecule_yml
@@ -514,3 +517,84 @@ def test_migrate_skill_unchanged_is_left_alone(collection_path: Path, output: Ou
 
     Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
     assert skill.read_text() == original
+
+
+def test_migrate_detects_cross_dependencies(tmp_path: Path, output: Output) -> None:
+    """Detect cross-target role references in meta/main.yml.
+
+    Args:
+        tmp_path: Temporary directory path.
+        output: Output class object.
+    """
+    collection = tmp_path / "ns" / "col"
+    collection.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    _write_role_target(targets, "setup_db")
+    target_app = _write_role_target(targets, "app")
+    meta = target_app / "meta"
+    meta.mkdir()
+    (meta / "main.yml").write_text("---\ndependencies:\n  - role: setup_db\n")
+
+    Migrate(_migrate_config(output, collection, migrate_all=True)).run()
+
+    next_steps = collection / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md"
+    content = next_steps.read_text()
+    assert "setup_db" in content
+    assert "Cross-target role dependencies" in content
+
+
+def test_migrate_no_cross_dependencies(collection_path: Path, output: Output) -> None:
+    """No cross-dependency section when targets are independent.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
+    Migrate(_migrate_config(output, collection_path, migrate_all=True)).run()
+
+    next_steps = collection_path / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md"
+    content = next_steps.read_text()
+    assert "Cross-target role dependencies" not in content
+
+
+def test_migrate_next_steps_respects_no_overwrite(
+    collection_path: Path,
+    output: Output,
+) -> None:
+    """Keep existing MIGRATE_NEXT_STEPS.md when --no-overwrite is set.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    next_steps = collection_path / "extensions" / "molecule" / "MIGRATE_NEXT_STEPS.md"
+    next_steps.write_text("# my custom notes\n")
+
+    Migrate(
+        _migrate_config(
+            output,
+            collection_path,
+            target_name="beta",
+            keep_targets=True,
+            no_overwrite=True,
+        ),
+    ).run()
+    assert next_steps.read_text() == "# my custom notes\n"
+
+
+def test_migrate_default_scenario_preserved(collection_path: Path, output: Output) -> None:
+    """Do not overwrite an existing default scenario on later runs.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    default_mol = collection_path / "extensions" / "molecule" / "default" / "molecule.yml"
+    default_mol.write_text("# custom default\n")
+
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    assert default_mol.read_text() == "# custom default\n"

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -53,18 +53,23 @@ def _migrate_config(
     keep_targets: bool = False,
     overwrite: bool = False,
     no_overwrite: bool = False,
+    force: bool = False,
+    migrate_type: str = "molecule",
+    skip_collection_check: bool = False,
 ) -> Config:
     return Config(
         creator_version="0.0.1",
         output=output,
         subcommand="migrate",
-        migrate_type="molecule",
+        migrate_type=migrate_type,
         target_name=target_name,
         migrate_all=migrate_all,
         keep_targets=keep_targets,
         path=str(path),
         overwrite=overwrite,
         no_overwrite=no_overwrite,
+        force=force,
+        skip_collection_check=skip_collection_check,
     )
 
 
@@ -176,3 +181,166 @@ def test_migrate_overwrite(collection_path: Path, output: Output) -> None:
         / "tasks"
         / "main.yaml"
     ).is_file()
+
+
+def test_migrate_unsupported_type(collection_path: Path, output: Output) -> None:
+    with pytest.raises(CreatorError, match="Unsupported migrate type"):
+        Migrate(
+            _migrate_config(output, collection_path, target_name="alpha", migrate_type="galaxy"),
+        ).run()
+
+
+def test_migrate_path_missing(tmp_path: Path, output: Output) -> None:
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(CreatorError, match="does not exist"):
+        Migrate(_migrate_config(output, missing, target_name="alpha")).run()
+
+
+def test_migrate_not_a_collection(tmp_path: Path, output: Output) -> None:
+    path = tmp_path / "not-a-collection"
+    path.mkdir()
+    with pytest.raises(CreatorError, match="not a valid Ansible collection"):
+        Migrate(_migrate_config(output, path, target_name="alpha")).run()
+
+
+def test_migrate_skip_collection_check(tmp_path: Path, output: Output) -> None:
+    collection = tmp_path / "loose"
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    _write_role_target(targets, "alpha")
+
+    Migrate(
+        _migrate_config(
+            output,
+            collection,
+            target_name="alpha",
+            skip_collection_check=True,
+        ),
+    ).run()
+    assert (
+        collection / "extensions" / "molecule" / "alpha" / "roles" / "content" / "tasks" / "main.yml"
+    ).is_file()
+
+
+def test_migrate_missing_targets_dir(tmp_path: Path, output: Output) -> None:
+    collection = tmp_path / "ns" / "col"
+    collection.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    with pytest.raises(CreatorError, match="No integration targets directory"):
+        Migrate(_migrate_config(output, collection, migrate_all=True)).run()
+
+
+def test_migrate_all_none_role_shaped(tmp_path: Path, output: Output) -> None:
+    collection = tmp_path / "ns" / "col"
+    targets = collection / "tests" / "integration" / "targets"
+    targets.mkdir(parents=True)
+    (collection / "galaxy.yml").write_text("namespace: ns\nname: col\nversion: 1.0.0\n")
+    script_only = targets / "scripty"
+    script_only.mkdir()
+    (script_only / "runme.sh").write_text("#!/bin/sh\necho hi\n")
+
+    with pytest.raises(CreatorError, match="No role-shaped"):
+        Migrate(_migrate_config(output, collection, migrate_all=True)).run()
+
+
+def test_migrate_prompt_declines_overwrite(
+    collection_path: Path,
+    output: Output,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    with pytest.raises(CreatorError, match="aborted due to existing content"):
+        Migrate(
+            _migrate_config(output, collection_path, target_name="alpha", keep_targets=True),
+        ).run()
+
+
+def test_migrate_prompt_accepts_overwrite(
+    collection_path: Path,
+    output: Output,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    Migrate(
+        _migrate_config(output, collection_path, target_name="alpha", keep_targets=True),
+    ).run()
+    assert (
+        collection_path
+        / "extensions"
+        / "molecule"
+        / "alpha"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yml"
+    ).is_file()
+
+
+def test_migrate_force_overwrite(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    Migrate(
+        _migrate_config(
+            output,
+            collection_path,
+            target_name="alpha",
+            keep_targets=True,
+            force=True,
+        ),
+    ).run()
+    assert (
+        collection_path
+        / "extensions"
+        / "molecule"
+        / "alpha"
+        / "roles"
+        / "content"
+        / "tasks"
+        / "main.yml"
+    ).is_file()
+
+
+def test_migrate_skips_rewriting_shared_config(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    config_path = collection_path / "extensions" / "molecule" / "config.yml"
+    inventory_path = collection_path / "extensions" / "molecule" / "inventory.yml"
+    config_path.write_text("# custom shared config\n")
+    inventory_path.write_text("# custom inventory\n")
+
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    assert config_path.read_text() == "# custom shared config\n"
+    assert inventory_path.read_text() == "# custom inventory\n"
+
+
+def test_migrate_skill_no_overwrite_keeps_custom(
+    collection_path: Path,
+    output: Output,
+) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    skill = (
+        collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
+    )
+    skill.write_text("# custom skill\n")
+
+    Migrate(
+        _migrate_config(
+            output,
+            collection_path,
+            target_name="beta",
+            keep_targets=True,
+            no_overwrite=True,
+        ),
+    ).run()
+    assert skill.read_text() == "# custom skill\n"
+
+
+def test_migrate_skill_unchanged_is_left_alone(collection_path: Path, output: Output) -> None:
+    Migrate(_migrate_config(output, collection_path, target_name="alpha", keep_targets=True)).run()
+    skill = (
+        collection_path / ".agents" / "skills" / "molecule-migrate-finalize" / "SKILL.md"
+    )
+    original = skill.read_text()
+
+    Migrate(_migrate_config(output, collection_path, target_name="beta", keep_targets=True)).run()
+    assert skill.read_text() == original

--- a/tests/units/test_migrate.py
+++ b/tests/units/test_migrate.py
@@ -230,6 +230,17 @@ def test_migrate_missing_target(collection_path: Path, output: Output) -> None:
         Migrate(_migrate_config(output, collection_path, target_name="missing")).run()
 
 
+def test_migrate_rejects_path_traversal(collection_path: Path, output: Output) -> None:
+    """Reject target names that escape the targets directory.
+
+    Args:
+        collection_path: Seeded collection path.
+        output: Output class object.
+    """
+    with pytest.raises(CreatorError, match="resolves outside"):
+        Migrate(_migrate_config(output, collection_path, target_name="../../etc")).run()
+
+
 def test_migrate_no_overwrite(collection_path: Path, output: Output) -> None:
     """Fail when scenario paths exist and --no-overwrite is set.
 


### PR DESCRIPTION
## Summary

Implements the **migration path** from the [Unified Collection Testing Strategy](https://github.com/ansible/handbook/pull/1520): move role-shaped `tests/integration/targets/` trees into real on-disk Molecule scenarios under `extensions/molecule/<target>/`.

This is the **tooling half** of the pilot; the **collection half** and CI proof live in [ansible-collections/ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444). Migrated collections are meant to be run by [ansible/tox-ansible#585](https://github.com/ansible/tox-ansible/pull/585) (`molecule` test type + `--matrix-scope molecule`).

### What changed

- `ansible-creator migrate molecule [<target>|--all]` for role-shaped ansible-test targets.
- Ansible-native shared config: `extensions/molecule/config.yml` + `inventory.yml` (`localhost` / `ansible_connection: local`); playbook-adjacent `roles/content/` + `include_role: name: content`.
- Ship `MIGRATE_NEXT_STEPS.md`, agent skill (`.agents/skills/molecule-migrate-finalize/`), and docs in `docs/agents.md`.
- Layout matches what landed in [ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444).

### Story / merge order

1. Strategy: [handbook#1520](https://github.com/ansible/handbook/pull/1520)
2. **This PR** — migration CLI + docs/skill
3. [tox-ansible#585](https://github.com/ansible/tox-ansible/pull/585) — native molecule envs for local + CI
4. [ansible.utils#444](https://github.com/ansible-collections/ansible.utils/pull/444) — first collection pilot (uses this migrate output; CI via workflow dispatch on that branch)

## Test plan

- [ ] `pytest tests/units/test_migrate.py`
- [ ] `pytest tests/integration/test_migrate.py` (tox env with installed CLI)
- [ ] Smoke: `ansible-creator migrate molecule --all --path /path/to/collection` on a collection with role-shaped targets
- [ ] `molecule test -s <scenario>` after migrate (with ADE/collection install)
- [ ] Compare output layout to [ansible.utils `extensions/molecule/`](https://github.com/ansible-collections/ansible.utils/tree/migrate-integration-to-molecule/extensions/molecule)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ansible-creator migrate molecule` to convert eligible role-shaped ansible-test integration targets into Molecule scenarios under `extensions/molecule/`, supporting single-target or `--all` migration, optional preservation of originals, and overwrite controls.
  * Generates required scenario files plus shared Molecule config and inventory, and produces migration guidance including cross-target dependency notes.
* **Bug Fixes**
  * Improved CLI workspace/path handling so `migrate` behaves consistently with other subcommands.
* **Documentation**
  * Expanded Molecule migration “next steps” and added a maintainer finalize workflow guide.
* **Tests**
  * Added CLI integration and extensive unit tests covering validation, migration outputs, idempotency, and overwrite behavior.
* **Chores**
  * Updated internal dictionary entries and adjusted init-time bundle visibility for the migration bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->