### PR TITLE
feat(ee): add --ee-type decision_environment for EDA scaffolding

### DIFF
--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -744,6 +744,16 @@ class Parser:
             help="The destination directory for the EE project.",
         )
 
+        parser.add_argument(
+            "--ee-type",
+            dest="ee_type",
+            default="standard",
+            choices=["standard", "decision_environment"],
+            help="Type of execution environment to scaffold. "
+            "'decision_environment' pre-populates EDA dependencies "
+            "(ansible-rulebook, java, ansible.eda collection). Default: standard",
+        )
+
         from ansible_creator.types import EEConfig  # noqa: PLC0415
 
         ee_config_group = parser.add_mutually_exclusive_group()

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -48,6 +48,7 @@ class Config:
         ee_name: Name/tag for the execution environment image.
         ee_file_name: Name of the EE definition file.
         ee_build_arg_defaults: EE build ARG defaults as KEY=VALUE strings (from CLI).
+        ee_type: Type of EE to scaffold (standard or decision_environment).
         registry_tls_verify: Whether to verify TLS for container registry operations
             (login, pull, push, and image builds). None means the user did not
             explicitly set this flag, so the EE config file value is preserved.
@@ -83,6 +84,7 @@ class Config:
     ee_system_packages: Sequence[str] = field(default_factory=list)
     ee_name: str = "ansible_sample_ee"
     ee_file_name: str = "execution-environment.yml"
+    ee_type: str = "standard"
     ee_build_arg_defaults: Sequence[str] = field(default_factory=list)
     registry_tls_verify: bool | None = None
     scm_provider: str = "github"

--- a/src/ansible_creator/config.py
+++ b/src/ansible_creator/config.py
@@ -47,8 +47,8 @@ class Config:
         ee_system_packages: List of system packages for execution environment.
         ee_name: Name/tag for the execution environment image.
         ee_file_name: Name of the EE definition file.
-        ee_build_arg_defaults: EE build ARG defaults as KEY=VALUE strings (from CLI).
         ee_type: Type of EE to scaffold (standard or decision_environment).
+        ee_build_arg_defaults: EE build ARG defaults as KEY=VALUE strings (from CLI).
         registry_tls_verify: Whether to verify TLS for container registry operations
             (login, pull, push, and image builds). None means the user did not
             explicitly set this flag, so the EE config file value is preserved.

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -70,6 +70,8 @@ class Init:
         self._include: list[str] = list(config.include)
         self._exclude: list[str] = list(config.exclude)
 
+        self._ee_type: str = getattr(config, "ee_type", "standard")
+
         # Build the canonical EEConfig from JSON, file, or defaults, then
         # layer CLI flag overrides on top.
         self._ee_config: EEConfig = self._build_ee_config(config)
@@ -177,6 +179,12 @@ class Init:
     def _build_ee_config(self, config: Config) -> EEConfig:
         """Build the final EEConfig by merging JSON/file config with CLI flags.
 
+        When ``ee_type`` is ``decision_environment`` and no explicit
+        ``--ee-config`` / ``--ee-config-file`` was provided, EDA-specific
+        defaults (base image, ansible-rulebook, java, ansible.eda) are
+        applied before CLI flag overrides, so ``--ee-base-image`` etc.
+        still win.
+
         Args:
             config: The application configuration.
 
@@ -184,6 +192,15 @@ class Init:
             A fully resolved EEConfig instance.
         """
         ee_cfg = self._resolve_ee_config(config)
+
+        if (
+            self._ee_type == "decision_environment"
+            and not config.ee_config
+            and not config.ee_config_file
+        ):
+            from ansible_creator.types import DE_DEFAULTS  # noqa: PLC0415
+
+            ee_cfg = dataclasses.replace(ee_cfg, **DE_DEFAULTS)
 
         overrides = Init._ee_cli_flag_overrides(config, ee_cfg, self._parse_single_collection)
         if overrides:

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -758,9 +758,24 @@ OFFICIAL_EE_IMAGES: tuple[OfficialEEImage, ...] = (
     OfficialEEImage("ee-supported-rhel", _PY311),
     OfficialEEImage("ee-29-rhel", _PY311),
     OfficialEEImage("ee-dellos", _PY311),
+    # Official Decision Environment images (EDA)
+    OfficialEEImage("de-minimal-rhel", _PY312),
+    OfficialEEImage("de-supported-rhel", _PY312),
 )
 
 DEFAULT_PYTHON_PATH = "/usr/bin/python3"
+
+DE_BASE_IMAGE = (
+    "registry.redhat.io/ansible-automation-platform-25/de-supported-rhel9:latest"
+)
+
+DE_DEFAULTS: dict[str, Any] = {
+    "base_image": DE_BASE_IMAGE,
+    "ee_name": "ansible_sample_de",
+    "python_deps": ("ansible-rulebook",),
+    "system_packages": ("java-17-openjdk-headless [platform:rpm]",),
+    "collections": (EECollection(name="ansible.eda"),),
+}
 
 
 @dataclass

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -765,9 +765,7 @@ OFFICIAL_EE_IMAGES: tuple[OfficialEEImage, ...] = (
 
 DEFAULT_PYTHON_PATH = "/usr/bin/python3"
 
-DE_BASE_IMAGE = (
-    "registry.redhat.io/ansible-automation-platform-25/de-supported-rhel9:latest"
-)
+DE_BASE_IMAGE = "registry.redhat.io/ansible-automation-platform-25/de-supported-rhel9:latest"
 
 DE_DEFAULTS: dict[str, Any] = {
     "base_image": DE_BASE_IMAGE,

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -69,6 +69,7 @@ class ConfigDict(TypedDict, total=False):
     ee_build_arg_defaults: list[str]
     registry_tls_verify: bool | None
     scm_provider: str
+    ee_type: str
 
 
 @pytest.fixture(name="output")
@@ -2150,3 +2151,116 @@ def test_ee_project_with_scm_servers_gitlab(
     ns = next_steps.read_text()
     assert "CI/CD" in ns
     assert "Actions" not in ns
+
+
+# ---------------------------------------------------------------------------
+# Decision Environment (EDA) scaffolding tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_ee_project_decision_env(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test Init.run() scaffolds a decision environment with EDA defaults.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "de_project")
+    cli_args["ee_type"] = "decision_environment"
+
+    init = Init(Config(**cli_args))
+    init.run()
+    result = capsys.readouterr().out
+
+    assert r"Note: execution_env project created" in result
+
+    ee_file = tmp_path / "de_project" / "execution-environment.yml"
+    ee_content = ee_file.read_text()
+
+    assert "de-supported-rhel9" in ee_content
+    assert "ansible-rulebook" in ee_content
+    assert "java-17-openjdk-headless" in ee_content
+    assert "ansible.eda" in ee_content
+    assert "ansible_sample_de" in ee_content
+
+    assert "package_manager_path: /usr/bin/microdnf" in ee_content
+
+
+def test_ee_project_de_cli_override(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test that CLI flags override DE defaults.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "de_override")
+    cli_args["ee_type"] = "decision_environment"
+    cli_args["base_image"] = "quay.io/custom/de:latest"
+    cli_args["ee_name"] = "my-custom-de"
+
+    init = Init(Config(**cli_args))
+    init.run()
+    result = capsys.readouterr().out
+
+    assert r"Note: execution_env project created" in result
+
+    ee_file = tmp_path / "de_override" / "execution-environment.yml"
+    ee_content = ee_file.read_text()
+
+    assert "quay.io/custom/de:latest" in ee_content
+    assert "my-custom-de" in ee_content
+    assert "ansible-rulebook" in ee_content
+    assert "ansible.eda" in ee_content
+
+
+def test_ee_project_de_with_config_file(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test that --ee-config takes precedence over DE defaults.
+
+    When a user provides an explicit EE config, DE defaults are not
+    applied — the config file is the source of truth.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    config_data = {
+        "name": "custom-de",
+        "base_image": "quay.io/fedora/fedora:41",
+        "collections": [{"name": "ansible.posix"}],
+    }
+
+    cli_args["project"] = "execution_env"
+    cli_args["init_path"] = str(tmp_path / "de_config")
+    cli_args["ee_type"] = "decision_environment"
+    cli_args["ee_config"] = json.dumps(config_data)
+
+    init = Init(Config(**cli_args))
+    init.run()
+    result = capsys.readouterr().out
+
+    assert r"Note: execution_env project created" in result
+
+    ee_file = tmp_path / "de_config" / "execution-environment.yml"
+    ee_content = ee_file.read_text()
+
+    assert "custom-de" in ee_content
+    assert "ansible.posix" in ee_content
+    assert "ansible-rulebook" not in ee_content
+    assert "ansible.eda" not in ee_content

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -47,6 +47,7 @@ class ConfigDict(TypedDict, total=False):
         ee_build_arg_defaults: EE build ARG defaults as KEY=VALUE strings (CLI).
         registry_tls_verify: Whether to verify TLS for container registries.
         scm_provider: SCM provider for EE CI (github or gitlab).
+        ee_type: Type of EE to scaffold (standard or decision_environment).
     """
 
     creator_version: str


### PR DESCRIPTION
## Summary

- Adds `--ee-type {standard,decision_environment}` flag to `ansible-creator init execution_env`
- When `decision_environment` is selected, pre-populates EDA-specific defaults:
  - Base image: `de-supported-rhel9`
  - Python deps: `ansible-rulebook`
  - System packages: `java-17-openjdk-headless`
  - Collections: `ansible.eda`
  - Image tag: `ansible_sample_de`
- CLI flags (`--ee-base-image`, `--ee-collections`, etc.) still override DE defaults
- `--ee-config` / `--ee-config-file` takes full precedence (DE defaults not applied)

## Motivation

This addresses a gap in the EDA developer workflow identified by @dafnemendoza: building Decision Environments currently requires manual knowledge of EDA-specific dependencies (ansible-rulebook, java, ansible.eda). The existing EE scaffolding template is already fully parameterized — this change simply adds a DE-specific defaults layer.

No changes needed in ansible-builder; the v3 EE schema already handles DE deps as ordinary entries.

## Files changed

| File | Change |
|------|--------|
| `arg_parser.py` | New `--ee-type` CLI argument |
| `config.py` | New `ee_type` field on Config dataclass |
| `types.py` | DE images in `OFFICIAL_EE_IMAGES`, `DE_DEFAULTS` constant |
| `subcommands/init.py` | Apply DE defaults in `_build_ee_config()` |
| `test_init_ee.py` | 3 new test cases (DE scaffolding, CLI override, config precedence) |

## Test plan

- [x] All 86 existing EE tests pass
- [x] 3 new DE-specific tests pass
- [x] Manual smoke test: `ansible-creator init execution_env --ee-type decision_environment` produces correct output
- [x] `--help` shows new flag with description
- [ ] Upstream CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--ee-type {standard,decision_environment}` (default: `standard`) for initializing execution environments.
  * Decision Environment scaffolding now includes predefined dependencies, packages, collections, and supported official base-image patterns.
  * Defaults apply only when no explicit EE configuration is provided; CLI `base_image` and `ee_name` values override them.
* **Tests**
  * Added coverage for Decision Environment defaults, overrides, and explicit configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->