### PR TITLE
fix(ci): set caller permissions matching reusable workflows

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -9,6 +9,13 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
+
+# Caller must grant at least the permissions required by team-devtools ack.yml.
+permissions:
+  checks: write # required-labels / status checks
+  contents: write # needed to update release draft
+  pull-requests: write # PR approval, labels, and merge
+
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/ack.yml@main

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -9,7 +9,6 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
-
 # Caller must grant at least the permissions required by team-devtools ack.yml.
 permissions:
   checks: write # required-labels / status checks

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,6 @@ on:
       - "releases/**"
       - "stable/**"
   workflow_dispatch:
-
 # Caller must grant at least the permissions required by team-devtools push.yml.
 permissions:
   contents: write # release-drafter updates the draft release notes

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,12 @@ on:
       - "releases/**"
       - "stable/**"
   workflow_dispatch:
+
+# Caller must grant at least the permissions required by team-devtools push.yml.
+permissions:
+  contents: write # release-drafter updates the draft release notes
+  pull-requests: read
+
 jobs:
   ack:
     uses: ansible/team-devtools/.github/workflows/push.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ name: release
 on:
   release:
     types: [published]
-
 permissions:
   contents: read # checkout source for the build
   id-token: write # PyPI trusted publishing (OIDC)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,15 @@ name: release
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read # checkout source for the build
+  id-token: write # PyPI trusted publishing (OIDC)
+
 jobs:
   release:
     environment: release
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
 
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_call:
-
 # Caller must grant at least the permissions required by team-devtools tox.yml.
 # Narrower scopes (e.g. contents: read only) cause reusable workflow startup_failure.
 permissions:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,6 +15,16 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_call:
+
+# Caller must grant at least the permissions required by team-devtools tox.yml.
+# Narrower scopes (e.g. contents: read only) cause reusable workflow startup_failure.
+permissions:
+  checks: read
+  contents: read
+  id-token: write # OIDC tokens used by reusable tox jobs
+  packages: write # some tox environments might produce containers
+  pull-requests: write # allow codenotify to comment on pull-request
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Satisfy CodeQL actions/missing-workflow-permissions without blocking team-devtools reusable workflows (regression from #617/#620).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows with explicit access permissions.
  * Improved workflow compatibility with reusable automation and release processes.
  * Preserved existing triggers and job behavior while clarifying required permission scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->