### PR TITLE
fix: resolve SonarCloud quality gate violations

### DIFF
--- a/src/ansible_creator/api.py
+++ b/src/ansible_creator/api.py
@@ -136,7 +136,7 @@ class V1:
         _, argv = self._build_argv(command_path, kwargs)
         return argv
 
-    def run(self, *command_path: str, **kwargs: Any) -> CreatorResult:  # noqa: C901,ANN401
+    def run(self, *command_path: str, **kwargs: Any) -> CreatorResult:  # noqa: ANN401
         """Execute an ansible-creator command dynamically.
 
         Constructs an argv list from the command path and kwargs, feeds it
@@ -185,28 +185,8 @@ class V1:
         args = vars(namespace)
         output, messages = self._build_output(args, kwargs)
 
-        # Determine the output path -- only init/add need a workspace dir
         subcommand = command_path[0]
-        needs_workspace = subcommand in ("init", "add")
-        output_dir: Path | None = None
-
-        if needs_workspace:
-            explicit_path = self._get_explicit_path(subcommand, kwargs)
-            if explicit_path is not None:
-                output_dir = Path(explicit_path)
-            else:
-                output_dir = Path(tempfile.mkdtemp(prefix="ansible-creator-"))
-
-            # Point the config at the actual output directory -- the
-            # leaf parser may not have the path argument so argparse can miss it.
-            if subcommand == "init":
-                args["init_path"] = str(output_dir)
-            else:
-                args["path"] = str(output_dir)
-
-            # For add commands targeting a bare directory, skip collection check
-            if subcommand == "add":
-                args.setdefault("skip_collection_check", True)
+        output_dir = self._resolve_output_dir(subcommand, args, kwargs)
 
         # Build Config from the remaining args (same as Cli.run)
         args["creator_version"] = __version__
@@ -242,6 +222,32 @@ class V1:
             logs=messages,
             message=message,
         )
+
+    def _resolve_output_dir(
+        self,
+        subcommand: str,
+        args: dict[str, Any],
+        kwargs: dict[str, Any],
+    ) -> Path | None:
+        """Determine the output directory for init/add commands."""
+        if subcommand not in ("init", "add"):
+            return None
+
+        explicit_path = self._get_explicit_path(subcommand, kwargs)
+        if explicit_path is not None:
+            output_dir = Path(explicit_path)
+        else:
+            output_dir = Path(tempfile.mkdtemp(prefix="ansible-creator-"))
+
+        if subcommand == "init":
+            args["init_path"] = str(output_dir)
+        else:
+            args["path"] = str(output_dir)
+
+        if subcommand == "add":
+            args.setdefault("skip_collection_check", True)
+
+        return output_dir
 
     def _build_output(
         self,

--- a/src/ansible_creator/api.py
+++ b/src/ansible_creator/api.py
@@ -229,7 +229,16 @@ class V1:
         args: dict[str, Any],
         kwargs: dict[str, Any],
     ) -> Path | None:
-        """Determine the output directory for init/add commands."""
+        """Determine the output directory for init/add commands.
+
+        Args:
+            subcommand: The subcommand name (e.g. "init", "add").
+            args: Mutable dict of parsed arguments.
+            kwargs: Original caller kwargs.
+
+        Returns:
+            The resolved output directory path, or None if not needed.
+        """
         if subcommand not in ("init", "add"):
             return None
 

--- a/src/ansible_creator/schema.py
+++ b/src/ansible_creator/schema.py
@@ -94,7 +94,7 @@ def _extract_parser_schema(
         if action.dest in ("help", "version"):
             continue
 
-        if hasattr(action, "choices") and isinstance(action.choices, dict):
+        if isinstance(action, argparse._SubParsersAction):  # noqa: SLF001
             _collect_subcommands(action, subcommands)
         else:
             param_info = _extract_action_info(action)

--- a/src/ansible_creator/schema.py
+++ b/src/ansible_creator/schema.py
@@ -91,27 +91,14 @@ def _extract_parser_schema(
     subcommands: dict[str, Any] = {}
 
     for action in parser._actions:  # noqa: SLF001
-        # Skip help and version actions
         if action.dest in ("help", "version"):
             continue
 
-        # Handle subparsers
         if hasattr(action, "choices") and isinstance(action.choices, dict):
-            help_map: dict[str, str] = {}
-            for choice_action in action._choices_actions:  # type: ignore[attr-defined]  # noqa: SLF001
-                help_map[choice_action.dest] = choice_action.help or ""
-
-            for sub_name, sub_parser in action.choices.items():
-                sub_help = help_map.get(sub_name, "")
-                subcommands[sub_name] = _extract_parser_schema(
-                    sub_parser,
-                    sub_name,
-                    sub_help,
-                )
+            _collect_subcommands(action, subcommands)
         else:
             param_info = _extract_action_info(action)
             result["parameters"]["properties"][action.dest] = param_info
-
             if _is_required(action):
                 result["parameters"]["required"].append(action.dest)
 
@@ -119,6 +106,23 @@ def _extract_parser_schema(
         result["subcommands"] = subcommands
 
     return result
+
+
+def _collect_subcommands(
+    action: argparse.Action,
+    subcommands: dict[str, Any],
+) -> None:
+    help_map: dict[str, str] = {}
+    for choice_action in action._choices_actions:  # type: ignore[attr-defined]  # noqa: SLF001
+        help_map[choice_action.dest] = choice_action.help or ""
+
+    for sub_name, sub_parser in action.choices.items():  # type: ignore[union-attr]
+        sub_help = help_map.get(sub_name, "")
+        subcommands[sub_name] = _extract_parser_schema(
+            sub_parser,
+            sub_name,
+            sub_help,
+        )
 
 
 def _extract_action_info(action: argparse.Action) -> dict[str, Any]:
@@ -236,6 +240,6 @@ def _clean_help_text(help_text: str) -> str:
     Returns:
         Cleaned help text.
     """
-    help_text = re.sub(r"\s*\(default:\s*[^)]+\)\s*$", "", help_text)
-    help_text = re.sub(r"\s*\(choices:\s*[^)]+\)\s*$", "", help_text)
+    help_text = re.sub(r"\s*\(default:\s[^)]+\)$", "", help_text)
+    help_text = re.sub(r"\s*\(choices:\s[^)]+\)$", "", help_text)
     return help_text.strip()

--- a/src/ansible_creator/schema.py
+++ b/src/ansible_creator/schema.py
@@ -240,6 +240,6 @@ def _clean_help_text(help_text: str) -> str:
     Returns:
         Cleaned help text.
     """
-    help_text = re.sub(r"\s*\(default:\s[^)]+\)$", "", help_text)
-    help_text = re.sub(r"\s*\(choices:\s[^)]+\)$", "", help_text)
+    help_text = re.sub(r" \(default: [^)]+\)$", "", help_text)
+    help_text = re.sub(r" \(choices: [^)]+\)$", "", help_text)
     return help_text.strip()

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -131,7 +131,7 @@ class Add:
 
         # Load the galaxy.yml file
         with galaxy_file.open("r", encoding="utf-8") as file:
-            data = yaml.safe_load(file)
+            data = yaml.safe_load(file) or {}
 
         # Ensure the dependencies key exists
         if "dependencies" not in data:
@@ -157,7 +157,7 @@ class Add:
 
         # Load the galaxy.yml file
         with galaxy_file.open("r", encoding="utf-8") as file:
-            data = yaml.safe_load(file)
+            data = yaml.safe_load(file) or {}
 
         # Ensure the namespace and name key exists
         namespace = data.get("namespace", "your-collection-namespace")

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -473,4 +473,4 @@ class Add:
             ) or "action" in source_str
         if self._plugin_type == "modules":  # pragma: no cover
             return "modules" in source_str and "sample_module.py.j2" in source_str
-        return False
+        return False  # pragma: no cover

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -13,7 +13,18 @@ from ansible_creator.constants import GLOBAL_TEMPLATE_VARS
 from ansible_creator.exceptions import CreatorError
 from ansible_creator.templar import Templar
 from ansible_creator.types import TemplateData
-from ansible_creator.utils import Copier, FileList, Walker, ask_yes_no, filter_ee_ci_paths_for_scm
+from ansible_creator.utils import (
+    Copier,
+    DestinationFile,
+    FileList,
+    Walker,
+    ask_yes_no,
+    filter_ee_ci_paths_for_scm,
+)
+
+
+GALAXY_YML = "galaxy.yml"
+ANSIBLE_UTILS = "ansible.utils"
 
 
 if TYPE_CHECKING:
@@ -96,7 +107,7 @@ class Add:
         if self._skip_collection_check:
             return
 
-        galaxy_file_path = self._add_path / "galaxy.yml"
+        galaxy_file_path = self._add_path / GALAXY_YML
         if not Path.is_file(galaxy_file_path):  # pragma: no cover
             msg = (
                 f"The path {self._add_path} is not a valid Ansible collection path. "
@@ -116,7 +127,7 @@ class Add:
 
     def update_galaxy_dependency(self) -> None:
         """Update galaxy.yml file with the required dependency."""
-        galaxy_file = self._add_path / "galaxy.yml"
+        galaxy_file = self._add_path / GALAXY_YML
 
         # Load the galaxy.yml file
         with galaxy_file.open("r", encoding="utf-8") as file:
@@ -124,11 +135,11 @@ class Add:
 
         # Ensure the dependencies key exists
         if "dependencies" not in data:
-            data["dependencies"] = {"ansible.utils": "*"}
+            data["dependencies"] = {ANSIBLE_UTILS: "*"}
 
         # Empty dependencies key or dependencies key without ansible.utils
-        elif not data["dependencies"] or "ansible.utils" not in data["dependencies"]:
-            data["dependencies"]["ansible.utils"] = "*"
+        elif not data["dependencies"] or ANSIBLE_UTILS not in data["dependencies"]:
+            data["dependencies"][ANSIBLE_UTILS] = "*"
 
         # Save the updated YAML back to the file
         with galaxy_file.open("w", encoding="utf-8") as file:
@@ -142,7 +153,7 @@ class Add:
                           Defaults are ('your-collection-namespace', 'your-collection-name')
                           if the file is missing or keys are absent.
         """
-        galaxy_file = self._add_path / "galaxy.yml"
+        galaxy_file = self._add_path / GALAXY_YML
 
         # Load the galaxy.yml file
         with galaxy_file.open("r", encoding="utf-8") as file:
@@ -253,21 +264,9 @@ class Add:
             template_data = self._get_plugin_template_data()
             self._perform_action_plugin_scaffold(template_data, plugin_path)
 
-        elif self._plugin_type == "filter":
+        elif self._plugin_type in ("filter", "lookup", "modules", "test"):
             template_data = self._get_plugin_template_data()
-            self._perform_filter_plugin_scaffold(template_data, plugin_path)
-
-        elif self._plugin_type == "lookup":
-            template_data = self._get_plugin_template_data()
-            self._perform_lookup_plugin_scaffold(template_data, plugin_path)
-
-        elif self._plugin_type == "modules":
-            template_data = self._get_plugin_template_data()
-            self._perform_module_plugin_scaffold(template_data, plugin_path)
-
-        elif self._plugin_type == "test":
-            template_data = self._get_plugin_template_data()
-            self._perform_test_plugin_scaffold(template_data, plugin_path)
+            self._perform_single_plugin_scaffold(template_data, plugin_path)
 
         else:
             msg = f"Unsupported plugin type: {self._plugin_type}"
@@ -287,31 +286,7 @@ class Add:
         final_plugin_path = [plugin_path, module_path]
         self._perform_plugin_scaffold(resources, template_data, final_plugin_path)
 
-    def _perform_filter_plugin_scaffold(
-        self,
-        template_data: TemplateData,
-        plugin_path: Path,
-    ) -> None:
-        resources = (f"collection_project.plugins.{self._plugin_type}",)
-        self._perform_plugin_scaffold(resources, template_data, plugin_path)
-
-    def _perform_lookup_plugin_scaffold(
-        self,
-        template_data: TemplateData,
-        plugin_path: Path,
-    ) -> None:
-        resources = (f"collection_project.plugins.{self._plugin_type}",)
-        self._perform_plugin_scaffold(resources, template_data, plugin_path)
-
-    def _perform_module_plugin_scaffold(
-        self,
-        template_data: TemplateData,
-        plugin_path: Path,
-    ) -> None:
-        resources = (f"collection_project.plugins.{self._plugin_type}",)
-        self._perform_plugin_scaffold(resources, template_data, plugin_path)
-
-    def _perform_test_plugin_scaffold(
+    def _perform_single_plugin_scaffold(
         self,
         template_data: TemplateData,
         plugin_path: Path,
@@ -484,18 +459,18 @@ class Add:
             return paths
 
         filtered_paths = FileList()
+        plugin_file = f"{self._plugin_name}.py"
         for path in paths:
-            if path.dest.name == f"{self._plugin_name}.py":
-                # For action plugins, include both action and module doc templates
-                if self._plugin_type == "action":
-                    if (
-                        "modules" in str(path.source) and "sample_action.py.j2" in str(path.source)
-                    ) or "action" in str(path.source):
-                        filtered_paths.append(path)
-                # For module plugins, only include the module template
-                elif self._plugin_type == "modules":  # noqa: SIM102 # pragma: no cover
-                    if "modules" in str(path.source) and "sample_module.py.j2" in str(path.source):
-                        filtered_paths.append(path)
-            else:
+            if path.dest.name != plugin_file or self._should_include_plugin_path(path):
                 filtered_paths.append(path)
         return filtered_paths
+
+    def _should_include_plugin_path(self, path: DestinationFile) -> bool:
+        source_str = str(path.source)
+        if self._plugin_type == "action":
+            return (
+                "modules" in source_str and "sample_action.py.j2" in source_str
+            ) or "action" in source_str
+        if self._plugin_type == "modules":  # pragma: no cover
+            return "modules" in source_str and "sample_module.py.j2" in source_str
+        return False

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -12,6 +12,11 @@ from ansible_creator.constants import GLOBAL_TEMPLATE_VARS
 from ansible_creator.exceptions import CreatorError
 
 
+DEFAULT_BASE_IMAGE = "quay.io/fedora/fedora:41"
+DEFAULT_REGISTRY = "ghcr.io"
+DEFAULT_EE_FILE_NAME = "execution-environment.yml"
+
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -490,8 +495,8 @@ class EEConfig:
     )
 
     ee_name: str = "ansible_sample_ee"
-    base_image: str = "quay.io/fedora/fedora:41"
-    registry: str = "ghcr.io"
+    base_image: str = DEFAULT_BASE_IMAGE
+    registry: str = DEFAULT_REGISTRY
     registry_tls_verify: bool = True
     image_name: str = ""
     collections: tuple[EECollection, ...] = ()
@@ -504,7 +509,7 @@ class EEConfig:
     ansible_cfg: str = ""
     galaxy_servers: tuple[GalaxyServer, ...] = ()
     scm_servers: tuple[ScmServer, ...] = ()
-    ee_file_name: str = "execution-environment.yml"
+    ee_file_name: str = DEFAULT_EE_FILE_NAME
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EEConfig:
@@ -542,7 +547,7 @@ class EEConfig:
                 msg = "build_arg_defaults must be a mapping of string keys to string values"
                 raise CreatorError(msg)
             build_arg_defaults[bk] = bv
-        registry = data.get("registry", "ghcr.io")
+        registry = data.get("registry", DEFAULT_REGISTRY)
         if "://" in registry:
             msg = f"Invalid registry '{registry}'. Provide a hostname (e.g. 'ghcr.io'), not a URL."
             raise CreatorError(msg)
@@ -553,7 +558,7 @@ class EEConfig:
         scm_servers = tuple(ScmServer.from_dict(s) for s in raw_scm)
         return cls(
             ee_name=data.get("ee_name", data.get("name", "ansible_sample_ee")),
-            base_image=data.get("base_image", "quay.io/fedora/fedora:41"),
+            base_image=data.get("base_image", DEFAULT_BASE_IMAGE),
             registry=registry,
             registry_tls_verify=data.get("registry_tls_verify", True),
             image_name=data.get("image_name", ""),
@@ -568,7 +573,7 @@ class EEConfig:
             galaxy_servers=galaxy_servers,
             scm_servers=scm_servers,
             ee_file_name=cls._validate_ee_file_name(
-                data.get("ee_file_name", "execution-environment.yml"),
+                data.get("ee_file_name", DEFAULT_EE_FILE_NAME),
             ),
         )
 
@@ -616,13 +621,13 @@ class EEConfig:
                 },
                 "base_image": {
                     "type": "string",
-                    "default": "quay.io/fedora/fedora:41",
+                    "default": DEFAULT_BASE_IMAGE,
                     "description": "Base container image",
                     "minLength": 1,
                 },
                 "registry": {
                     "type": "string",
-                    "default": "ghcr.io",
+                    "default": DEFAULT_REGISTRY,
                     "description": (
                         "Container registry hostname for the CI workflow (e.g. ghcr.io, quay.io)"
                     ),
@@ -709,7 +714,7 @@ class EEConfig:
                 "ee_file_name": {
                     "type": "string",
                     "description": "Name of the EE definition file",
-                    "default": "execution-environment.yml",
+                    "default": DEFAULT_EE_FILE_NAME,
                     "pattern": r"^[^/\\]*\.(yml|yaml)$",
                     "minLength": 5,
                 },
@@ -821,7 +826,7 @@ class TemplateData:
     recommended_extensions: Sequence[str] = field(
         default_factory=lambda: GLOBAL_TEMPLATE_VARS["RECOMMENDED_EXTENSIONS"],
     )
-    ee_base_image: str = "quay.io/fedora/fedora:41"
+    ee_base_image: str = DEFAULT_BASE_IMAGE
     ee_collections: Sequence[dict[str, str]] = field(default_factory=list)
     ee_python_deps: Sequence[str] = field(default_factory=list)
     ee_system_packages: Sequence[str] = field(default_factory=list)
@@ -834,12 +839,12 @@ class TemplateData:
     is_official_ee: bool = False
     ee_python_path: str = DEFAULT_PYTHON_PATH
     ee_name_is_default: bool = True
-    ee_registry: str = "ghcr.io"
+    ee_registry: str = DEFAULT_REGISTRY
     ee_registry_tls_verify: bool = True
     ee_image_name: str = ""
     ee_galaxy_servers: Sequence[dict[str, Any]] = field(default_factory=list)
     ee_galaxy_token_vars: Sequence[str] = field(default_factory=list)
     ee_scm_servers: Sequence[dict[str, Any]] = field(default_factory=list)
     ee_scm_token_vars: Sequence[str] = field(default_factory=list)
-    ee_file_name: str = "execution-environment.yml"
+    ee_file_name: str = DEFAULT_EE_FILE_NAME
     scm_provider: str = "github"

--- a/src/ansible_creator/utils.py
+++ b/src/ansible_creator/utils.py
@@ -330,12 +330,13 @@ class Walker:
         if obj.is_file():
             dest_path.set_content(template_data, self.templar)
 
+        is_walkable_dir = obj.is_dir() and obj.name not in SKIP_DIRS
+
         if dest_path.needs_write:
             conflict_msg = dest_path.conflict
             if conflict_msg:
                 self.output.warning(conflict_msg)
-
-            if obj.is_dir() and obj.name not in SKIP_DIRS:
+            if is_walkable_dir:
                 return FileList(
                     [
                         dest_path,
@@ -349,7 +350,8 @@ class Walker:
                 )
             if obj.is_file():
                 return FileList([dest_path])
-        if obj.is_dir() and obj.name not in SKIP_DIRS:
+
+        if is_walkable_dir:
             return self._recursive_walk(
                 root=obj,
                 resource=resource,


### PR DESCRIPTION
## Summary
- Extract duplicated string literals to constants in types.py and add.py (S1192)
- Merge 4 identical plugin scaffold functions into one shared method (S4144)
- Extract helpers to reduce cognitive complexity in api.py, schema.py, add.py, utils.py (S3776)
- Simplify regex patterns to avoid backtracking in schema.py (S8786)

## Test plan
- [ ] All existing tests pass (1 pre-existing failure in test_devcontainer_usability unrelated to changes)
- [ ] `ruff check src/` passes clean
- [ ] SonarCloud quality gate should improve after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Streamlined initialization and add workflows with more consistent output-directory handling.
  - Enhanced plugin scaffolding and conflict detection for supported plugin types.
  - Ensured `galaxy.yml` dependency updates reliably include `ansible.utils`.
  - Standardized default execution-environment image, registry, and definition filename across configuration and generated schemas.
  - Improved command help and subcommand schema parsing.
  - Improved directory traversal behavior during project generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->