### PR TITLE
feat: add resource playbook for simple playbook scaffold

### DIFF
--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -131,7 +131,7 @@ class Parser:
                     prefix=Level.ERROR,
                     message="Missing required argument 'resource-type'.\n"
                     "Choose from: devcontainer, devfile, ee-ci, execution-environment, "
-                    "play-argspec, role",
+                    "play-argspec, playbook, role",
                 )
             )
             self.exit_code = os.EX_USAGE
@@ -294,6 +294,7 @@ class Parser:
         self._add_resource_ee_ci(subparser=subparser)
         self._add_resource_execution_env(subparser=subparser)
         self._add_resource_play_argspec(subparser=subparser)
+        self._add_resource_playbook(subparser=subparser)
         self._add_resource_role(subparser=subparser)
 
     def _add_resource_ai(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
@@ -446,6 +447,29 @@ class Parser:
             metavar="path",
             nargs="?",
             help="The destination directory for the playbook argspec files. The default is the "
+            "current working directory.",
+        )
+
+        self._add_overwrite(parser)
+        self._add_args_common(parser)
+
+    def _add_resource_playbook(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Add a sample Ansible playbook file to an existing path.
+
+        Args:
+            subparser: The subparser to add the playbook file to
+        """
+        parser = subparser.add_parser(
+            "playbook",
+            help="Add a sample Ansible playbook file to an existing path.",
+        )
+
+        parser.add_argument(
+            "path",
+            default="./",
+            metavar="path",
+            nargs="?",
+            help="The destination directory for the playbook file. The default is the "
             "current working directory.",
         )
 

--- a/src/ansible_creator/bundles.py
+++ b/src/ansible_creator/bundles.py
@@ -18,6 +18,7 @@ _INIT_EXCLUDED_BUNDLES: frozenset[str] = frozenset(
         "ee-ci",
         "execution-environment",
         "play-argspec",
+        "playbook",
     },
 )
 

--- a/src/ansible_creator/resources/common/playbook/playbook.yml.j2
+++ b/src/ansible_creator/resources/common/playbook/playbook.yml.j2
@@ -1,0 +1,9 @@
+---
+- name: Example playbook
+  hosts: localhost
+  gather_facts: true
+
+  tasks:
+    - name: Print a greeting
+      ansible.builtin.debug:
+        msg: Hello from Ansible

--- a/src/ansible_creator/subcommands/add.py
+++ b/src/ansible_creator/subcommands/add.py
@@ -181,7 +181,7 @@ class Add:
             template_data = self._get_devcontainer_template_data()
         elif self._resource_type == "execution-environment":
             template_data = self._get_ee_template_data()
-        elif self._resource_type in {"play-argspec", "ai", "ee-ci"}:
+        elif self._resource_type in {"play-argspec", "playbook", "ai", "ee-ci"}:
             template_data = self._get_template_data()
         elif self._resource_type == "role":
             self._check_collection_path()

--- a/tests/units/test_add.py
+++ b/tests/units/test_add.py
@@ -879,6 +879,34 @@ def test_run_success_add_execution_env(
     assert "Note: Resource added to" in result
 
 
+def test_run_success_add_playbook(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Test Add.run() for adding a sample playbook file.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Add class object.
+    """
+    cli_args["resource_type"] = "playbook"
+    add = Add(
+        Config(**cli_args),
+    )
+    add.run()
+    result = capsys.readouterr().out
+    assert "Note: Resource added to" in result
+
+    playbook = tmp_path / "playbook.yml"
+    assert playbook.exists()
+    content = playbook.read_text()
+    assert "name: Example playbook" in content
+    assert "hosts: localhost" in content
+    assert "ansible.builtin.debug" in content
+
+
 def test_run_success_add_play_argspec(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,

--- a/tests/units/test_api.py
+++ b/tests/units/test_api.py
@@ -435,6 +435,31 @@ def test_add_resource_execution_environment(creator_api: V1, tmp_path: Path) -> 
     assert (target / "execution-environment.yml").exists()
 
 
+def test_add_resource_playbook(creator_api: V1, tmp_path: Path) -> None:
+    """Test adding a sample playbook resource.
+
+    Args:
+        creator_api: V1 API instance.
+        tmp_path: Temporary directory path.
+    """
+    target = tmp_path / "play"
+    target.mkdir()
+    result = creator_api.run(
+        "add",
+        "resource",
+        "playbook",
+        path=str(target),
+    )
+    assert result.status == "success", result.message
+    assert result.path == target
+    playbook = target / "playbook.yml"
+    assert playbook.exists()
+    content = playbook.read_text()
+    assert "name: Example playbook" in content
+    assert "hosts: localhost" in content
+    assert "ansible.builtin.debug" in content
+
+
 def test_add_resource_ai(creator_api: V1, tmp_path: Path) -> None:
     """Test adding AI agent helper files.
 


### PR DESCRIPTION
## Summary
- Add `ansible-creator add resource playbook` to scaffold a sample single-file `playbook.yml`.
- Enables IDEs/MCP (vscode-ansible AAP-81422) to create a simple playbook without scaffolding a full playbook project.

## Changes
- New resource bundle `resources/common/playbook/playbook.yml.j2` (localhost + `ansible.builtin.debug` starter)
- CLI subparser `add resource playbook` (path + overwrite flags)
- Exclude `playbook` from init `--include/--exclude` common bundles
- Unit tests for Add CLI and V1 API paths

## Why
`ansible-creator init playbook` creates a full project. Consumers need a best-practice **single-file** example that can be the source of truth for “create simple playbook” UX, instead of hardcoded templates in the editor.

Companion extension PR: https://github.com/ansible/vscode-ansible/pull/3062

## Test plan
- [x] `uv run pytest tests/units/test_add.py tests/units/test_api.py tests/units/test_bundles.py -k "playbook or bundles"`
- [ ] `ansible-creator add resource playbook /tmp/demo` creates `/tmp/demo/playbook.yml`
- [ ] `ansible-creator schema` includes `add → resource → playbook`
- [ ] Full tox / CI green

related: AAP-81422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating Ansible playbook resources via the CLI and API.
  * Playbooks now scaffold an example targeting `localhost` with fact gathering and a debug task.
  * Introduced a `path` argument for playbook creation (defaulting to the current directory).
* **Bug Fixes**
  * Improved “resource-type” validation messaging by including playbook in the supported type list.
* **Tests**
  * Added unit coverage for successful playbook scaffolding through both CLI and API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->