### PR TITLE
docs: document add resource playbook

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -400,7 +400,7 @@ ansible-creator add resource <resource-type> <path>
 | devfile               | Add a devfile file to an existing Ansible project.                 |
 | execution-environment | Add a sample execution-environment.yml file to an existing path.   |
 | play-argspec          | Add playbook argspec examples file to an existing Ansible project. |
-| playbook              | Add a sample single-file playbook.yml to an existing path.         |
+| playbook              | Add a sample playbook.yml to an existing path.                     |
 | role                  | Add a role to an existing Ansible collection.                      |
 
 #### Example of adding a resource
@@ -418,7 +418,7 @@ ansible-creator add resource playbook /home/user/..path/to/your/existing_project
 
 This command will scaffold a sample `playbook.yml` at
 `/home/user/..path/to/your/existing_project`. Use this when you need a
-single-file starter playbook rather than a full `init playbook` project.
+sample playbook rather than a full `init playbook` project.
 
 ### Add plugins to an existing ansible collection
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -400,6 +400,7 @@ ansible-creator add resource <resource-type> <path>
 | devfile               | Add a devfile file to an existing Ansible project.                 |
 | execution-environment | Add a sample execution-environment.yml file to an existing path.   |
 | play-argspec          | Add playbook argspec examples file to an existing Ansible project. |
+| playbook              | Add a sample single-file playbook.yml to an existing path.         |
 | role                  | Add a role to an existing Ansible collection.                      |
 
 #### Example of adding a resource
@@ -410,6 +411,14 @@ ansible-creator add resource devcontainer /home/user/..path/to/your/existing_pro
 
 This command will scaffold the devcontainer directory at
 `/home/user/..path/to/your/existing_project`
+
+```console
+ansible-creator add resource playbook /home/user/..path/to/your/existing_project
+```
+
+This command will scaffold a sample `playbook.yml` at
+`/home/user/..path/to/your/existing_project`. Use this when you need a
+single-file starter playbook rather than a full `init playbook` project.
 
 ### Add plugins to an existing ansible collection
 


### PR DESCRIPTION
## Summary
- Document `ansible-creator add resource playbook` in the installing docs (resource table + example).
- Follow-up to #634: the resource landed without CLI docs; vscode-ansible should not own this reference.

## Changes
- Add `playbook` to the `add resource` positional arguments table
- Add an example that scaffolds a sample `playbook.yml` (vs full `init playbook` project)

## Test plan
- [x] Docs render correctly on Read the Docs / local mkdocs preview
- [x] Example matches CLI: `ansible-creator add resource playbook <path>`

related: AAP-81422
related: #634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to recognize `playbook` as a supported “add resource” type.
  * Expanded the “Example of adding a resource” section with a command to scaffold a starter playbook.
  * Documented that the command creates a `playbook.yml` at the specified path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->