### PR TITLE
feat(de): add decision_environment as first-class init project type

### DIFF
--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -868,9 +868,11 @@ class Parser:
         )
         parser.add_argument(
             "init_path",
+            default="./",
             metavar="path",
             nargs="?",
-            help="The destination directory for the decision environment project.",
+            help="The destination directory for the decision environment project. "
+            "The default is the current working directory.",
         )
 
         self._add_ee_build_args(parser)
@@ -889,9 +891,11 @@ class Parser:
         )
         parser.add_argument(
             "init_path",
+            default="./",
             metavar="path",
             nargs="?",
-            help="The destination directory for the EE project.",
+            help="The destination directory for the EE project. "
+            "The default is the current working directory.",
         )
 
         self._add_ee_build_args(parser)

--- a/src/ansible_creator/arg_parser.py
+++ b/src/ansible_creator/arg_parser.py
@@ -102,7 +102,7 @@ class Parser:
                 Msg(
                     prefix=Level.ERROR,
                     message="Missing required argument 'project-type'.\n"
-                    "Choose from: collection, playbook, execution_env",
+                    "Choose from: collection, decision_environment, playbook, execution_env",
                 )
             )
             self.exit_code = os.EX_USAGE
@@ -666,6 +666,7 @@ class Parser:
         )
 
         self._init_collection(subparser=subparser)
+        self._init_de_project(subparser=subparser)
         self._init_playbook(subparser=subparser)
         self._init_ee_project(subparser=subparser)
 
@@ -751,23 +752,12 @@ class Parser:
         self._add_args_init_common(parser)
         self._add_include_exclude(parser)
 
-    def _init_ee_project(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
-        """Initialize an EE project.
+    def _add_ee_build_args(self, parser: argparse.ArgumentParser) -> None:
+        """Add shared EE/DE build arguments to *parser*.
 
         Args:
-            subparser: The subparser to add EE project to
+            parser: The parser to add EE build arguments to
         """
-        parser = subparser.add_parser(
-            "execution_env",
-            help="Create a new execution environment project.",
-        )
-        parser.add_argument(
-            "init_path",
-            metavar="path",
-            nargs="?",
-            help="The destination directory for the EE project.",
-        )
-
         from ansible_creator.types import EEConfig  # noqa: PLC0415
 
         ee_config_group = parser.add_mutually_exclusive_group()
@@ -792,98 +782,119 @@ class Parser:
             "--ee-base-image",
             dest="base_image",
             default="quay.io/fedora/fedora:41",
-            help="Base image for the execution environment. Default: quay.io/fedora/fedora:41",
+            help="Base container image. Default: quay.io/fedora/fedora:41",
         )
-        base_image_action.schema_metadata = {  # type: ignore[attr-defined]
-            "minLength": 1,
-        }
-
+        base_image_action.schema_metadata = {"minLength": 1}  # type: ignore[attr-defined]
         ee_collections_action = parser.add_argument(
             "--ee-collections",
             dest="ee_collections",
             action="append",
             default=[],
             metavar="COLLECTION",
-            help="Ansible collection to include (can be specified multiple times). "
-            "Supports formats: 'name', 'name:version', or 'name:version:type:source'. "
-            "Example: --ee-collections ansible.posix --ee-collections 'ansible.utils:>=1.0.0' "
-            "--ee-collections 'my.collection:1.0.0:galaxy:https://galaxy.ansible.com'",
+            help="Ansible collection to include (repeatable). "
+            "Formats: 'name', 'name:version', or 'name:version:type:source'.",
         )
         ee_collections_action.schema_metadata = {  # type: ignore[attr-defined]
             "items": {"type": "string", "minLength": 1},
             "minItems": 0,
         }
-
         parser.add_argument(
             "--ee-python-deps",
             dest="ee_python_deps",
             action="append",
             default=[],
             metavar="PACKAGE",
-            help="Python package dependency (can be specified multiple times). "
-            "Example: --ee-python-deps requests --ee-python-deps boto3",
+            help="Python package dependency (repeatable).",
         )
-
         parser.add_argument(
             "--ee-system-packages",
             dest="ee_system_packages",
             action="append",
             default=[],
             metavar="PACKAGE",
-            help="System package dependency (can be specified multiple times). "
-            "Example: --ee-system-packages openssh-clients --ee-system-packages sshpass",
+            help="System package dependency (repeatable).",
         )
-
         ee_name_action = parser.add_argument(
             "--ee-name",
             default="ansible_sample_ee",
-            help="Name/tag for the execution environment image. Default: ansible_sample_ee",
+            help="Name/tag for the built image. Default: ansible_sample_ee",
         )
         ee_name_action.schema_metadata = {"minLength": 1}  # type: ignore[attr-defined]
-
         ee_file_name_action = parser.add_argument(
             "--ee-file-name",
             dest="ee_file_name",
             default="execution-environment.yml",
             type=EEConfig._validate_ee_file_name,  # noqa: SLF001
-            help="Name of the EE definition file. "
-            "Must end with .yml or .yaml. Default: execution-environment.yml",
+            help="Name of the EE definition file (.yml/.yaml). Default: execution-environment.yml",
         )
         ee_file_name_action.schema_metadata = {  # type: ignore[attr-defined]
             "pattern": r"^[^/\\]*\.(yml|yaml)$",
             "minLength": 5,
         }
-
         parser.add_argument(
             "--ee-build-arg-default",
             dest="ee_build_arg_defaults",
             action="append",
             default=[],
             metavar="KEY=VALUE",
-            help="Default build ARG for the EE image (repeatable). "
-            "Example: --ee-build-arg-default ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre",
+            help="Default build ARG (repeatable). Example: "
+            "--ee-build-arg-default ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre",
         )
-
         parser.add_argument(
             "--registry-tls-verify",
             dest="registry_tls_verify",
             action=argparse.BooleanOptionalAction,
             default=None,
-            help="Verify TLS certificates when accessing container registries "
-            "(login, pull, push, and image builds). "
-            "Use --no-registry-tls-verify to disable. "
-            "Overrides the value from --ee-config/--ee-config-file when set explicitly.",
+            help="Verify TLS certificates for container registries. "
+            "Use --no-registry-tls-verify to disable.",
         )
-
         parser.add_argument(
             "--scm-provider",
             dest="scm_provider",
             default="github",
             choices=["github", "gitlab"],
-            help="SCM provider for the scaffolded EE CI files (GitHub Actions or GitLab CI). "
-            "Default: github",
+            help="SCM provider for the scaffolded CI files. Default: github",
         )
 
+    def _init_de_project(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Initialize a decision environment project.
+
+        Args:
+            subparser: The subparser to add DE project to
+        """
+        parser = subparser.add_parser(
+            "decision_environment",
+            help="Create a new decision environment project for Event-Driven Ansible.",
+        )
+        parser.add_argument(
+            "init_path",
+            metavar="path",
+            nargs="?",
+            help="The destination directory for the decision environment project.",
+        )
+
+        self._add_ee_build_args(parser)
+        self._add_args_common(parser)
+        self._add_args_init_common(parser)
+
+    def _init_ee_project(self, subparser: SubParser[argparse.ArgumentParser]) -> None:
+        """Initialize an EE project.
+
+        Args:
+            subparser: The subparser to add EE project to
+        """
+        parser = subparser.add_parser(
+            "execution_env",
+            help="Create a new execution environment project.",
+        )
+        parser.add_argument(
+            "init_path",
+            metavar="path",
+            nargs="?",
+            help="The destination directory for the EE project.",
+        )
+
+        self._add_ee_build_args(parser)
         self._add_args_common(parser)
         self._add_args_init_common(parser)
 
@@ -929,7 +940,7 @@ class Parser:
         parser.add_argument("--init-path", help="")
         args, extras = parser.parse_known_args()
 
-        if args.collection in {"playbook", "collection", "execution_env"}:
+        if args.collection in {"playbook", "collection", "decision_environment", "execution_env"}:
             return True
         if args.project:
             msg = "The `project` flag is no longer needed and will be removed."

--- a/src/ansible_creator/resources/decision_environment_project/.gitignore
+++ b/src/ansible_creator/resources/decision_environment_project/.gitignore
@@ -1,0 +1,2 @@
+context/
+.DS_Store

--- a/src/ansible_creator/resources/decision_environment_project/NEXT_STEPS.md.j2
+++ b/src/ansible_creator/resources/decision_environment_project/NEXT_STEPS.md.j2
@@ -1,0 +1,125 @@
+# Next Steps
+
+Complete the following setup to enable automated decision environment builds.
+
+{%- if scm_provider == "gitlab" %}
+{%- if ee_galaxy_token_vars or ee_scm_token_vars %}
+
+## Required CI/CD variables
+
+Configure these under **Settings > CI/CD > Variables** (mask sensitive values).
+{%- if ee_galaxy_token_vars %}
+
+### Galaxy server tokens
+
+These tokens authenticate `ansible-galaxy collection install` during the DE build.
+
+| Variable | Purpose |
+|----------|---------|
+{%- for var in ee_galaxy_token_vars %}
+| `{{ var }}` | Galaxy server authentication token |
+{%- endfor %}
+{%- endif %}
+{%- if ee_scm_token_vars %}
+
+### SCM tokens
+
+These tokens substitute into private collection Git URLs during the build (`envsubst` on `context/_build/requirements.yml`).
+
+| Variable | Purpose |
+|----------|---------|
+{%- for server in ee_scm_servers %}
+| `{{ server.token_env_var }}` | Git access for collections from `{{ server.hostname }}` |
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+
+## Optional CI/CD variables
+
+| Variable | Purpose |
+|----------|---------|
+| `REGISTRY_USERNAME` | Container registry username (defaults to `CI_REGISTRY_USER`) |
+| `REGISTRY_PASSWORD` | Container registry password (defaults to `CI_REGISTRY_PASSWORD`) |
+| `REDHAT_REGISTRY_PASSWORD` | Red Hat registry password (for pulling base images) |
+
+## Additional CI/CD variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EE_REGISTRY` | `{{ ee_registry }}` | Container registry hostname |
+| `EE_IMAGE_NAME` | (see `.gitlab-ci.yml`) | Image name in the registry |
+| `REDHAT_REGISTRY_USERNAME` | - | Red Hat registry username |
+
+## Verify your setup
+
+{% if ee_galaxy_token_vars or ee_scm_token_vars -%}
+1. Configure all required variables listed above
+{% else -%}
+1. Review the optional variables listed above and configure any you need
+{% endif -%}
+2. Run a pipeline (for example **CI/CD > Pipelines > Run pipeline**) or push a tag
+3. Open the pipeline job logs for any authentication errors
+4. Once the build succeeds, verify the image in your container registry
+
+{%- else %}
+{%- if ee_galaxy_token_vars or ee_scm_token_vars %}
+
+## Required Secrets
+
+Configure these secrets in **Settings > Secrets and variables > Actions > New repository secret**.
+{%- if ee_galaxy_token_vars %}
+
+### Galaxy Server Tokens
+
+These tokens authenticate `ansible-galaxy collection install` during the DE build.
+
+| Secret | Purpose |
+|--------|---------|
+{%- for var in ee_galaxy_token_vars %}
+| `{{ var }}` | Galaxy server authentication token |
+{%- endfor %}
+{%- endif %}
+{%- if ee_scm_token_vars %}
+
+### SCM Tokens
+
+These tokens authenticate `git clone` for private collection repositories.
+
+| Secret | Purpose |
+|--------|---------|
+{%- for server in ee_scm_servers %}
+| `{{ server.token_env_var }}` | Git access for collections from `{{ server.hostname }}` |
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+
+## Optional Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `REGISTRY_PASSWORD` | Container registry password (defaults to `GITHUB_TOKEN`) |
+| `REDHAT_REGISTRY_PASSWORD` | Red Hat registry password (for pulling base images) |
+
+## Repository Variables
+
+Configure these in **Settings > Secrets and variables > Actions > Variables**.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `REGISTRY_USERNAME` | `github.actor` | Username for the container registry where the built image will be pushed (defaults to `github.actor`) |
+| `EE_REGISTRY` | `{{ ee_registry }}` | Container registry hostname |
+| `EE_IMAGE_NAME` | `<owner>/<repo>` | Image name |
+| `REDHAT_REGISTRY_USERNAME` | - | Red Hat registry username |
+
+## Verify Your Setup
+
+{% if ee_galaxy_token_vars or ee_scm_token_vars -%}
+1. Configure all required secrets listed above
+{% else -%}
+1. Review the optional secrets listed above and configure any you need
+{% endif -%}
+2. Push to a branch or open a pull request to trigger the workflow
+3. Check the workflow run in **Actions** for any authentication errors
+4. Once the build succeeds, verify the image in your container registry
+
+{%- endif %}

--- a/src/ansible_creator/resources/decision_environment_project/NEXT_STEPS.md.j2
+++ b/src/ansible_creator/resources/decision_environment_project/NEXT_STEPS.md.j2
@@ -118,7 +118,7 @@ Configure these in **Settings > Secrets and variables > Actions > Variables**.
 {% else -%}
 1. Review the optional secrets listed above and configure any you need
 {% endif -%}
-2. Push to a branch or open a pull request to trigger the workflow
+2. Publish a release, or run the workflow manually from **Actions > Run workflow**, to trigger a build
 3. Check the workflow run in **Actions** for any authentication errors
 4. Once the build succeeds, verify the image in your container registry
 

--- a/src/ansible_creator/resources/decision_environment_project/README.md.j2
+++ b/src/ansible_creator/resources/decision_environment_project/README.md.j2
@@ -39,6 +39,10 @@ The included GitLab CI pipeline (`.gitlab-ci.yml`) provides:
 {%- else %}
 
 The included GitHub Actions workflow (`ee-build.yml`) provides:
+
+> **Note:** The workflow is named "Execution Environment Build" because decision
+> environments reuse the shared, ansible-builder-based EE build pipeline. The name
+> is cosmetic — the workflow builds your decision environment correctly.
 {%- endif %}
 
 ### Token Validation

--- a/src/ansible_creator/resources/decision_environment_project/README.md.j2
+++ b/src/ansible_creator/resources/decision_environment_project/README.md.j2
@@ -12,6 +12,7 @@ including collections, Python packages, and system libraries.
 ```shell
 ├── .gitlab-ci.yml          # GitLab CI/CD pipeline for building and publishing
 ├── .gitignore
+├── NEXT_STEPS.md
 ├── README.md
 └── {{ ee_file_name }}
 ```
@@ -23,6 +24,7 @@ including collections, Python packages, and system libraries.
 │   └── workflows
 │       └── ee-build.yml    # CI/CD workflow for building and publishing
 ├── .gitignore
+├── NEXT_STEPS.md
 ├── README.md
 └── {{ ee_file_name }}
 ```
@@ -47,7 +49,8 @@ The included GitHub Actions workflow (`ee-build.yml`) provides:
 ### Base Image Lifecycle Checks
 
 - Warns if the base image is older than 40 days
-- Fails if the base image is older than 80 days
+- Warns more prominently if the base image is older than 80 days
+- Annotations only — the age check never blocks the build
 - Helps ensure your DE stays up-to-date with security patches
 {%- if ee_galaxy_token_vars %}
 
@@ -143,9 +146,8 @@ podman build -t my-de:latest context/
 
 {%- else %}
 
-- **Pull Request**: Builds and tests the DE (no push to registry)
-- **Push to main**: Builds, tests, and pushes with `latest` and commit SHA tags
-- **Release**: Tags image with version number and `prd` tag
+- **Release (published)**: Builds the DE and tags the image with the release version and `prd` tag
+- **Manual dispatch** (Actions > Run workflow): Builds the DE on demand
 
 {%- endif %}
 

--- a/src/ansible_creator/resources/decision_environment_project/README.md.j2
+++ b/src/ansible_creator/resources/decision_environment_project/README.md.j2
@@ -1,0 +1,164 @@
+# Decision Environment Project
+
+This is a sample decision environment project for Event-Driven Ansible (EDA).
+
+Decision environments package the dependencies needed to run ansible-rulebook,
+including collections, Python packages, and system libraries.
+
+## Directory Structure
+
+{%- if scm_provider == "gitlab" %}
+
+```shell
+├── .gitlab-ci.yml          # GitLab CI/CD pipeline for building and publishing
+├── .gitignore
+├── README.md
+└── {{ ee_file_name }}
+```
+
+{%- else %}
+
+```shell
+├── .github
+│   └── workflows
+│       └── ee-build.yml    # CI/CD workflow for building and publishing
+├── .gitignore
+├── README.md
+└── {{ ee_file_name }}
+```
+
+{%- endif %}
+
+## CI/CD Workflow Features
+
+{%- if scm_provider == "gitlab" %}
+
+The included GitLab CI pipeline (`.gitlab-ci.yml`) provides:
+{%- else %}
+
+The included GitHub Actions workflow (`ee-build.yml`) provides:
+{%- endif %}
+
+### Token Validation
+
+- Validates configured tokens before starting builds
+- Fails fast if credentials are missing
+
+### Base Image Lifecycle Checks
+
+- Warns if the base image is older than 40 days
+- Fails if the base image is older than 80 days
+- Helps ensure your DE stays up-to-date with security patches
+{%- if ee_galaxy_token_vars %}
+
+### Galaxy Server Support
+
+- Supports authenticated Galaxy server access via token secrets
+- Falls back to public Galaxy if no token is configured
+{%- endif %}
+
+### Production Release Workflow
+
+- Automatic tagging on release
+- Preserves previous production image as `previous` tag for rollback
+- Supports semantic versioning
+
+## Required Secrets and Variables
+
+{%- if scm_provider == "gitlab" %}
+
+### CI/CD Variables (Settings > CI/CD > Variables)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+{%- for var in ee_galaxy_token_vars %}
+| `{{ var }}` | Yes | Galaxy server authentication token |
+{%- endfor %}
+{%- for server in ee_scm_servers %}
+| `{{ server.token_env_var }}` | Yes | Git access token for {{ server.hostname }} |
+{%- endfor %}
+| `REGISTRY_USERNAME` | No | Container registry username (defaults to `CI_REGISTRY_USER`) |
+| `REGISTRY_PASSWORD` | No | Container registry password (defaults to `CI_REGISTRY_PASSWORD`) |
+| `REDHAT_REGISTRY_PASSWORD` | No | Red Hat registry password (for pulling base images) |
+
+### Additional CI/CD Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EE_REGISTRY` | `{{ ee_registry }}` | Container registry hostname |
+| `EE_IMAGE_NAME` | `$CI_PROJECT_PATH` | Image name / path in the registry |
+| `REDHAT_REGISTRY_USERNAME` | - | Red Hat registry username |
+
+{%- else %}
+
+### Secrets (Repository Settings > Secrets)
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+{%- for var in ee_galaxy_token_vars %}
+| `{{ var }}` | Yes | Galaxy server authentication token |
+{%- endfor %}
+{%- for server in ee_scm_servers %}
+| `{{ server.token_env_var }}` | Yes | Git access token for {{ server.hostname }} |
+{%- endfor %}
+| `REGISTRY_USERNAME` | No | Container registry username (defaults to `github.actor`) |
+| `REGISTRY_PASSWORD` | No | Container registry password (defaults to `GITHUB_TOKEN`) |
+| `REDHAT_REGISTRY_PASSWORD` | No | Red Hat registry password (for pulling base images) |
+
+### Variables (Repository Settings > Variables)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EE_REGISTRY` | `{{ ee_registry }}` | Container registry hostname |
+| `EE_IMAGE_NAME` | `<owner>/<repo>` | Image name (GHCR requires the `owner/repo` namespace) |
+| `REDHAT_REGISTRY_USERNAME` | - | Red Hat registry username |
+
+{%- endif %}
+{%- if ee_galaxy_token_vars or ee_scm_token_vars %}
+
+See `NEXT_STEPS.md` for a complete setup checklist.
+{%- endif %}
+
+## Usage
+
+### Building Locally
+
+```bash
+# Install ansible-builder
+pip install ansible-builder
+
+# Create build context
+ansible-builder create --file {{ ee_file_name }}
+
+# Build the image
+podman build -t my-de:latest context/
+```
+
+### Triggering CI/CD
+
+{%- if scm_provider == "gitlab" %}
+
+- **Tag push**, **manual pipeline** (Run pipeline), **API**, or **pipeline trigger**: runs build and push
+- **Tag pipeline**: release job tags the image with the Git tag, `latest`, and `prd`
+
+{%- else %}
+
+- **Pull Request**: Builds and tests the DE (no push to registry)
+- **Push to main**: Builds, tests, and pushes with `latest` and commit SHA tags
+- **Release**: Tags image with version number and `prd` tag
+
+{%- endif %}
+
+## Customization
+
+Edit `{{ ee_file_name }}` to customize:
+
+- Base image
+- Ansible collections (e.g. `ansible.eda`)
+- Python dependencies (e.g. `ansible-rulebook`)
+- System packages (e.g. `java-17-openjdk-headless`)
+
+See the [ansible-builder documentation](https://ansible.readthedocs.io/projects/builder/en/latest/)
+for more details on execution environment configuration, and the
+[Event-Driven Ansible documentation](https://ansible.readthedocs.io/projects/rulebook/en/latest/)
+for decision environment guidance.

--- a/src/ansible_creator/resources/decision_environment_project/execution-environment.yml.j2
+++ b/src/ansible_creator/resources/decision_environment_project/execution-environment.yml.j2
@@ -1,0 +1,140 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: {{ ee_base_image }}
+{%- if ee_build_arg_defaults %}
+
+build_arg_defaults:
+{%- for key, val in ee_build_arg_defaults | dictsort %}
+  {{ key }}: {{ val | json }}
+{%- endfor %}
+{%- endif %}
+
+dependencies:
+{%- if not is_official_ee %}
+  # Use python3
+  python_interpreter:
+    package_system: python3
+    python_path: {{ ee_python_path }}
+
+  ansible_core:
+    package_pip: ansible-core
+
+  ansible_runner:
+    package_pip: ansible-runner
+{%- else %}
+  python_interpreter:
+    python_path: {{ ee_python_path }}
+{%- endif %}
+{%- if ee_system_packages %}
+
+  system:
+{%- for pkg in ee_system_packages %}
+    - {{ pkg }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_python_deps %}
+
+  python:
+{%- for dep in ee_python_deps %}
+    - {{ dep }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_collections %}
+
+  galaxy:
+    collections:
+{%- for col in ee_collections %}
+      - name: {{ col.name }}
+{%- if col.version is defined %}
+        version: "{{ col.version }}"
+{%- endif %}
+{%- if col.type is defined %}
+        type: {{ col.type }}
+{%- endif %}
+{%- if col.source is defined %}
+        source: {{ col.source }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if ee_additional_build_files %}
+
+additional_build_files:
+{%- for file in ee_additional_build_files %}
+  - src: {{ file.src }}
+    dest: {{ file.dest }}
+{%- endfor %}
+{%- endif %}
+{%- if not is_official_ee or ee_galaxy_token_vars or ee_additional_build_steps %}
+
+additional_build_steps:
+{%- if ee_additional_build_steps.prepend_base is defined %}
+  prepend_base:
+{%- for step in ee_additional_build_steps.prepend_base %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- if not is_official_ee or ee_additional_build_steps.append_base is defined %}
+  append_base:
+{%- if not is_official_ee %}
+    - RUN $PYCMD -m pip install -U pip
+{%- endif %}
+{%- if ee_additional_build_steps.append_base is defined %}
+{%- for step in ee_additional_build_steps.append_base %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+{%- if ee_galaxy_token_vars or ee_additional_build_steps.prepend_galaxy is defined %}
+  prepend_galaxy:
+{%- for var in ee_galaxy_token_vars %}
+    - ARG {{ var }}
+{%- endfor %}
+{%- if ee_additional_build_steps.prepend_galaxy is defined %}
+{%- for step in ee_additional_build_steps.prepend_galaxy %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+{%- if ee_additional_build_steps.append_galaxy is defined %}
+  append_galaxy:
+{%- for step in ee_additional_build_steps.append_galaxy %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_additional_build_steps.prepend_builder is defined %}
+  prepend_builder:
+{%- for step in ee_additional_build_steps.prepend_builder %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_additional_build_steps.append_builder is defined %}
+  append_builder:
+{%- for step in ee_additional_build_steps.append_builder %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_additional_build_steps.prepend_final is defined %}
+  prepend_final:
+{%- for step in ee_additional_build_steps.prepend_final %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- if ee_additional_build_steps.append_final is defined %}
+  append_final:
+{%- for step in ee_additional_build_steps.append_final %}
+    - {{ step }}
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+
+options:
+{%- if ee_options.package_manager_path is defined %}
+  package_manager_path: {{ ee_options.package_manager_path }}
+{%- endif %}
+{%- if not (is_official_ee and ee_name_is_default) %}
+  tags:
+    - {{ ee_name }}
+{%- endif %}

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -16,6 +16,7 @@ from ansible_creator.bundles import get_init_bundle_names
 from ansible_creator.exceptions import CreatorError
 from ansible_creator.templar import Templar
 from ansible_creator.types import (
+    DE_DEFAULTS,
     EECollection,
     EEConfig,
     TemplateData,
@@ -87,7 +88,7 @@ class Init:
 
     def _construct_init_path(self) -> None:
         """Construct the init path based on project type."""
-        if self._project in {"playbook", "execution_env"}:
+        if self._project in {"playbook", "execution_env", "decision_environment"}:
             return
 
         if (
@@ -135,20 +136,20 @@ class Init:
 
     @staticmethod
     def _is_official_ee_image(image: str) -> bool:
-        """Check if the image is an official Red Hat EE image.
+        """Check if the image is an official Red Hat EE or DE image.
 
-        Official EE images have ansible-core/runner pre-installed and
+        Official images have ansible-core/runner pre-installed and
         use microdnf as the package manager.
 
         Args:
             image: The container image name/URL.
 
         Returns:
-            True if the image matches any official EE pattern.
+            True if the image matches any official EE or DE pattern.
         """
-        from ansible_creator.types import OFFICIAL_EE_IMAGES  # noqa: PLC0415
+        from ansible_creator.types import ALL_OFFICIAL_IMAGES  # noqa: PLC0415
 
-        return any(entry.pattern in image for entry in OFFICIAL_EE_IMAGES)
+        return any(entry.pattern in image for entry in ALL_OFFICIAL_IMAGES)
 
     @staticmethod
     def _get_ee_python_path(image: str) -> str:
@@ -165,11 +166,11 @@ class Init:
             The Python interpreter path for the image.
         """
         from ansible_creator.types import (  # noqa: PLC0415
+            ALL_OFFICIAL_IMAGES,
             DEFAULT_PYTHON_PATH,
-            OFFICIAL_EE_IMAGES,
         )
 
-        for entry in OFFICIAL_EE_IMAGES:
+        for entry in ALL_OFFICIAL_IMAGES:
             if entry.pattern in image:
                 return entry.python_path
         return DEFAULT_PYTHON_PATH
@@ -269,6 +270,10 @@ class Init:
     def _resolve_ee_config(config: Config) -> EEConfig:
         """Resolve EE configuration from inline JSON or a config file.
 
+        For ``decision_environment`` projects, DE-specific defaults
+        (base image, collections, system packages) are applied when no
+        explicit ``--ee-config`` or ``--ee-config-file`` is provided.
+
         Args:
             config: The application configuration.
 
@@ -285,6 +290,8 @@ class Init:
             return Init._parse_ee_config_json(config.ee_config)
         if config.ee_config_file:
             return Init._load_ee_config_file(config.ee_config_file)
+        if config.project == "decision_environment":
+            return dataclasses.replace(EEConfig(), **DE_DEFAULTS)
         return EEConfig()
 
     @staticmethod
@@ -530,7 +537,7 @@ class Init:
             scm_provider=self._scm_provider,
         )
 
-        if self._project == "execution_env":
+        if self._project in {"execution_env", "decision_environment"}:
             resources = (f"{self._project}_project", "common.ee-ci")
         else:
             resolved = self._resolve_common_resources()
@@ -546,7 +553,7 @@ class Init:
         )
         paths = walker.collect_paths()
 
-        if self._project == "execution_env":
+        if self._project in {"execution_env", "decision_environment"}:
             paths = filter_ee_ci_paths_for_scm(paths, self._scm_provider)
 
         copier = Copier(
@@ -591,7 +598,7 @@ class Init:
         configuration is provided, such as ansible.cfg for EE projects.
         Respects the ``--no-overwrite`` / ``--overwrite`` flags.
         """
-        if self._project != "execution_env":
+        if self._project not in {"execution_env", "decision_environment"}:
             return
 
         ansible_cfg_path = self._init_path / "ansible.cfg"

--- a/src/ansible_creator/subcommands/init.py
+++ b/src/ansible_creator/subcommands/init.py
@@ -291,7 +291,7 @@ class Init:
         if config.ee_config_file:
             return Init._load_ee_config_file(config.ee_config_file)
         if config.project == "decision_environment":
-            return dataclasses.replace(EEConfig(), **DE_DEFAULTS)
+            return EEConfig(**DE_DEFAULTS)
         return EEConfig()
 
     @staticmethod

--- a/src/ansible_creator/types.py
+++ b/src/ansible_creator/types.py
@@ -760,7 +760,24 @@ OFFICIAL_EE_IMAGES: tuple[OfficialEEImage, ...] = (
     OfficialEEImage("ee-dellos", _PY311),
 )
 
+OFFICIAL_DE_IMAGES: tuple[OfficialEEImage, ...] = (
+    OfficialEEImage("de-minimal-rhel", _PY312),
+    OfficialEEImage("de-supported-rhel", _PY312),
+)
+
+ALL_OFFICIAL_IMAGES: tuple[OfficialEEImage, ...] = OFFICIAL_EE_IMAGES + OFFICIAL_DE_IMAGES
+
 DEFAULT_PYTHON_PATH = "/usr/bin/python3"
+
+DE_BASE_IMAGE = "registry.redhat.io/ansible-automation-platform-25/de-supported-rhel9:latest"
+
+DE_DEFAULTS: dict[str, Any] = {
+    "base_image": DE_BASE_IMAGE,
+    "ee_name": "ansible_sample_de",
+    "python_deps": ("ansible-rulebook",),
+    "system_packages": ("java-17-openjdk-headless [platform:rpm]",),
+    "collections": (EECollection(name="ansible.eda"),),
+}
 
 
 @dataclass

--- a/tests/fixtures/project/de_project/.github/workflows/ee-build.yml
+++ b/tests/fixtures/project/de_project/.github/workflows/ee-build.yml
@@ -1,0 +1,438 @@
+---
+# Execution Environment Build and Publish Workflow
+# Features:
+# - Galaxy server token configuration checks
+# - Support for private collection repositories (Git SCM tokens)
+# - Base image lifecycle checks
+# - Production release workflow with tagging
+# - Registry authentication for build and push
+#
+# Supported Secrets:
+#   Galaxy server tokens follow the Ansible naming convention:
+#     ANSIBLE_GALAXY_SERVER_<ID>_TOKEN
+#   where <ID> matches the [galaxy_server.<id>] section in ansible.cfg.
+#   REGISTRY_USERNAME, REGISTRY_PASSWORD   - Container registry credentials
+#   REDHAT_REGISTRY_PASSWORD     - Red Hat registry for base images
+#
+# Token Security:
+#   Galaxy server tokens are passed via Containerfile ARG directives and
+#   --build-arg, which are available during the build but do NOT persist
+#   in the final image (not in layers, metadata, or history).
+#   SCM tokens are resolved via envsubst into the build context after
+#   ansible-builder create. The multi-stage build ensures tokens only
+#   exist in intermediate stages, never in the final image.
+#   The ansible.cfg (server URLs only, no tokens) is volume-mounted into
+#   the build and also never enters any OCI layer.
+
+name: Execution Environment Build
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ee_dir:
+        description: "Directory containing the EE files (relative to repo root)"
+        required: false
+        default: "."
+        type: string
+      ee_file_name:
+        description: "EE definition file name"
+        required: false
+        default: "execution-environment.yml"
+        type: string
+      ee_registry:
+        description: "Container registry"
+        required: false
+        default: "ghcr.io"
+        type: string
+      ee_image_name:
+        description: "Container image name (defaults to repository name)"
+        required: false
+        default: ""
+        type: string
+      ee_registry_tls_verify:
+        description: "Verify TLS certificates for container registries (true/false)"
+        required: false
+        default: "true"
+        type: string
+      ee_image_build_tag:
+        description: "Custom image tag for the build (defaults to build-<commit SHA>)"
+        required: false
+        type: string
+      skip_base_image_validation:
+        description: "Skip base image validation"
+        required: false
+        default: "false"
+        type: boolean
+
+# Required for pushing images to GHCR
+permissions:
+  contents: read
+  packages: write
+
+# Prevent concurrent builds from racing to push the same image tag.
+# A static custom tag (e.g. vars.EE_IMAGE_BUILD_TAG=test) dispatched on
+# different refs would otherwise land in separate groups yet push to
+# the same registry tag. Including the resolved tag serialises them.
+concurrency:
+  group: ee-build-${{ github.ref }}-${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  cancel-in-progress: false
+
+env:
+  # Container registry configuration (override via repository Variables)
+  EE_REGISTRY: ${{ inputs.ee_registry || vars.EE_REGISTRY || 'ghcr.io' }}
+  EE_IMAGE_NAME: ${{ inputs.ee_image_name || vars.EE_IMAGE_NAME || github.repository }}
+  EE_REGISTRY_TLS_VERIFY: ${{ inputs.ee_registry_tls_verify || vars.EE_REGISTRY_TLS_VERIFY || 'true' }}
+  # EE directory and file name (override via workflow_dispatch inputs or repository Variables)
+  EE_DIR: ${{ inputs.ee_dir || vars.EE_DIR || '.' }}
+  EE_FILE_NAME: ${{ inputs.ee_file_name || vars.EE_FILE_NAME || 'execution-environment.yml' }}
+  # Image build tag (override via workflow_dispatch input or repository Variable)
+  EE_IMAGE_BUILD_TAG: ${{ inputs.ee_image_build_tag || vars.EE_IMAGE_BUILD_TAG || format('build-{0}', github.sha) }}
+  # Base image age thresholds (in days) - annotations only, never blocks the build
+  IMAGE_WARN_AGE: 40
+  IMAGE_FAIL_AGE: 80
+
+jobs:
+  # ============================================================================
+  # Validation Stage
+  # ============================================================================
+  validate-tokens:
+    name: Token Configuration
+    runs-on: ubuntu-latest
+    outputs:
+      galaxy_tokens_configured: ${{ steps.check-galaxy.outputs.configured }}
+      git_token_configured: ${{ steps.check-git-token.outputs.configured }}
+    steps:
+      - name: No galaxy server tokens required
+        id: check-galaxy
+        run: |
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No galaxy server tokens configured for this project"
+
+      - name: No SCM tokens required
+        id: check-git-token
+        run: |
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No SCM tokens configured for this project"
+
+
+  validate-image-tag:
+    name: Validate Image Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check EE_IMAGE_BUILD_TAG conforms to OCI tag spec
+        run: |
+          TAG="${{ env.EE_IMAGE_BUILD_TAG }}"
+          if [[ -z "$TAG" ]]; then
+            echo "::error::EE_IMAGE_BUILD_TAG is empty"
+            exit 1
+          fi
+          if [[ ${#TAG} -gt 128 ]]; then
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' exceeds 128 characters (OCI tag limit)"
+            exit 1
+          fi
+          if ! [[ "$TAG" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+            echo "::error::EE_IMAGE_BUILD_TAG '${TAG}' contains invalid characters."
+            echo "::error::Tags must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._-]"
+            exit 1
+          fi
+          echo "::notice::Image tag '${TAG}' is valid"
+
+  check-base-image:
+    name: Check Base Image Lifecycle
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.skip_base_image_validation != 'true'
+    outputs:
+      image_age_days: ${{ steps.check-age.outputs.age_days }}
+      image_status: ${{ steps.check-age.outputs.status }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Red Hat registry (for private base images)
+        if: vars.REDHAT_REGISTRY_USERNAME != ''
+        run: |
+          echo "${{ secrets.REDHAT_REGISTRY_PASSWORD }}" | \
+            podman login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+            -u "${{ vars.REDHAT_REGISTRY_USERNAME }}" \
+            --password-stdin registry.redhat.io
+
+      - name: Extract base image from ${{ env.EE_DIR }}/${{ env.EE_FILE_NAME }}
+        id: get-image
+        run: |
+          EE_DEF="${{ env.EE_DIR }}/${{ env.EE_FILE_NAME }}"
+          # Handle both flat and nested (v3) EE spec formats
+          if command -v yq &> /dev/null; then
+            BASE_IMAGE=$(yq -r '.images.base_image.name // .images.base_image // empty' \
+              "$EE_DEF" 2>/dev/null || echo "")
+          fi
+          if [[ -z "$BASE_IMAGE" ]]; then
+            BASE_IMAGE=$(grep -A2 'base_image:' "$EE_DEF" | \
+              grep -oP 'name:\s*\K\S+' || \
+              grep -oP 'base_image:\s*\K\S+' "$EE_DEF" || echo "")
+            BASE_IMAGE=$(echo "$BASE_IMAGE" | tr -d '"' | tr -d "'" | head -1)
+          fi
+          echo "base_image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "::notice::Base image: $BASE_IMAGE"
+
+      - name: Check base image age
+        id: check-age
+        env:
+          BASE_IMAGE: ${{ steps.get-image.outputs.base_image }}
+        run: |
+          if [[ -z "$BASE_IMAGE" ]]; then
+            echo "::warning::Could not determine base image, skipping age check"
+            echo "age_days=0" >> "$GITHUB_OUTPUT"
+            echo "status=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pull the image to inspect it
+          if ! podman pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} "$BASE_IMAGE" 2>/dev/null; then
+            echo "::warning::Could not pull base image, skipping age check"
+            echo "age_days=0" >> "$GITHUB_OUTPUT"
+            echo "status=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get image creation date
+          CREATED=$(podman inspect "$BASE_IMAGE" --format '{{.Created}}' 2>/dev/null || echo "")
+          if [[ -z "$CREATED" ]]; then
+            echo "::warning::Could not determine image creation date"
+            echo "age_days=0" >> "$GITHUB_OUTPUT"
+            echo "status=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Calculate age in days
+          CREATED_EPOCH=$(date -d "$CREATED" +%s 2>/dev/null || \
+            date -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED%%.*}" +%s 2>/dev/null || echo "0")
+          CURRENT_EPOCH=$(date +%s)
+          AGE_DAYS=$(( (CURRENT_EPOCH - CREATED_EPOCH) / 86400 ))
+
+          echo "age_days=$AGE_DAYS" >> "$GITHUB_OUTPUT"
+          echo "::notice::Base image is $AGE_DAYS days old"
+
+          if [[ $AGE_DAYS -gt ${{ env.IMAGE_FAIL_AGE }} ]]; then
+            echo "::warning::Base image is more than ${{ env.IMAGE_FAIL_AGE }} days old. Consider updating."
+            echo "status=stale" >> "$GITHUB_OUTPUT"
+          elif [[ $AGE_DAYS -gt ${{ env.IMAGE_WARN_AGE }} ]]; then
+            echo "::warning::Base image is more than ${{ env.IMAGE_WARN_AGE }} days old. Consider updating soon."
+            echo "status=warning" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ============================================================================
+  # Build Stage
+  # ============================================================================
+  build:
+    name: Build Execution Environment
+    runs-on: ubuntu-latest
+    needs: [validate-tokens, validate-image-tag, check-base-image]
+    # Runs even if check-base-image was skipped (workflow_dispatch) so builds are not blocked
+    if: |
+      always() &&
+      needs.validate-tokens.result == 'success' &&
+      needs.validate-image-tag.result == 'success' &&
+      (needs.check-base-image.result == 'success' || needs.check-base-image.result == 'skipped')
+    outputs:
+      image_digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ansible-builder
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible-builder ansible-core
+
+      - name: Login to container registry
+        run: |
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
+            echo "${{ secrets.GITHUB_TOKEN }}" | \
+              buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+              -u "${{ github.actor }}" \
+              --password-stdin "${{ env.EE_REGISTRY }}"
+          else
+            echo "${{ secrets.REGISTRY_PASSWORD }}" | \
+              buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+              -u "${{ vars.REGISTRY_USERNAME }}" \
+              --password-stdin "${{ env.EE_REGISTRY }}"
+          fi
+
+      - name: Login to Red Hat registry (for base images)
+        if: vars.REDHAT_REGISTRY_USERNAME != ''
+        run: |
+          echo "${{ secrets.REDHAT_REGISTRY_PASSWORD }}" | \
+            buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+            -u "${{ vars.REDHAT_REGISTRY_USERNAME }}" \
+            --password-stdin registry.redhat.io
+
+      - name: Verify buildah version
+        run: |
+          BUILDAH_VERSION=$(buildah --version | grep -oP '\d+\.\d+\.\d+' | head -1)
+          MAJOR=$(echo "$BUILDAH_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$BUILDAH_VERSION" | cut -d. -f2)
+          if [[ "$MAJOR" -lt 1 ]] || { [[ "$MAJOR" -eq 1 ]] && [[ "$MINOR" -lt 24 ]]; }; then
+            echo "::error::buildah $BUILDAH_VERSION is too old — 1.24+ required so ARG values are not leaked to image history (containers/buildah#3609)"
+            exit 1
+          fi
+          echo "::notice::buildah $BUILDAH_VERSION — ARG values will not appear in image history"
+
+      - name: Build execution environment
+        id: build
+        env:
+
+          # Use the repo's ansible.cfg for host-side dependency resolution
+          ANSIBLE_CONFIG: ./ansible.cfg
+        run: |
+          echo "::group::Creating build context"
+          echo "::notice::EE directory: ${{ env.EE_DIR }}"
+          ansible-builder create --file "${{ env.EE_DIR }}/${{ env.EE_FILE_NAME }}" --output-filename Containerfile
+
+
+          echo "::endgroup::"
+
+          echo "::group::Building image"
+
+          # Volume-mount ansible.cfg into the build (never enters any OCI layer).
+          # Ansible reads /etc/ansible/ansible.cfg as a fallback config path.
+          EXTRA_ARGS=()
+          if [[ -f "${{ env.EE_DIR }}/ansible.cfg" ]]; then
+            EXTRA_ARGS+=(--volume "$(pwd)/${{ env.EE_DIR }}/ansible.cfg:/etc/ansible/ansible.cfg:ro")
+          fi
+
+
+          buildah bud --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+            "${EXTRA_ARGS[@]}" \
+            --tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            --file context/Containerfile \
+            context/
+          echo "::endgroup::"
+
+      - name: Test execution environment
+        run: |
+          echo "::group::Testing EE"
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            ansible --version
+          podman run --rm "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            ansible-galaxy collection list || true
+          echo "::endgroup::"
+
+      - name: Push image
+        id: push
+        run: |
+          buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+            --digestfile /tmp/digest \
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+            "docker://${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
+          echo "digest=$(cat /tmp/digest)" >> "$GITHUB_OUTPUT"
+
+  # ============================================================================
+  # Release Stage
+  # ============================================================================
+  release:
+    name: Release Execution Environment
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == 'release'
+    steps:
+      - name: Login to container registry
+        run: |
+          if [[ "${{ env.EE_REGISTRY }}" == "ghcr.io" ]]; then
+            echo "${{ secrets.GITHUB_TOKEN }}" | \
+              buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+              -u "${{ github.actor }}" \
+              --password-stdin "${{ env.EE_REGISTRY }}"
+          else
+            echo "${{ secrets.REGISTRY_PASSWORD }}" | \
+              buildah login --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+              -u "${{ vars.REGISTRY_USERNAME }}" \
+              --password-stdin "${{ env.EE_REGISTRY }}"
+          fi
+
+      - name: Tag and push release
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          # Pull the image built from this commit (pushed in build job)
+          buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}"
+
+          # Backup previous production tag if it exists
+          if buildah pull --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+            "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" 2>/dev/null; then
+            echo "::notice::Backing up previous production image to 'previous' tag"
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:prd" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
+            buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:previous"
+          fi
+
+          # Tag and push version, latest, and production
+          for TAG in "${VERSION}" "latest" "prd"; do
+            buildah tag "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${{ env.EE_IMAGE_BUILD_TAG }}" \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
+            buildah push --tls-verify=${{ env.EE_REGISTRY_TLS_VERIFY }} \
+              "${{ env.EE_REGISTRY }}/${{ env.EE_IMAGE_NAME }}:${TAG}"
+          done
+
+          echo "::notice::Released version ${VERSION}"
+
+  # ============================================================================
+  # Summary
+  # ============================================================================
+  summary:
+    name: Build Summary
+    runs-on: ubuntu-latest
+    needs: [validate-tokens, validate-image-tag, check-base-image, build]
+    if: always()
+    steps:
+      - name: Generate summary
+        run: |
+          echo "## Execution Environment Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Validation Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Check | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Token Validation | ${{ needs.validate-tokens.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image Tag Validation | ${{ needs.validate-image-tag.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Base Image Check | ${{ needs.check-base-image.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Authentication Status" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Provider | Configured |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|------------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Galaxy Server Tokens | ${{ needs.validate-tokens.outputs.galaxy_tokens_configured }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| SCM Tokens | ${{ needs.validate-tokens.outputs.git_token_configured }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "${{ needs.check-base-image.outputs.image_age_days }}" != "" ]]; then
+            echo "### Base Image Status" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Age: ${{ needs.check-base-image.outputs.image_age_days }} days" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Status: ${{ needs.check-base-image.outputs.image_status }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "### Build Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Step | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Build | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "${{ needs.build.result }}" == "success" ]]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Image Details" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Registry: \`${{ env.EE_REGISTRY }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Image: \`${{ env.EE_IMAGE_NAME }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- EE Directory: \`${{ env.EE_DIR }}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/tests/fixtures/project/de_project/.gitignore
+++ b/tests/fixtures/project/de_project/.gitignore
@@ -1,0 +1,2 @@
+context/
+.DS_Store

--- a/tests/fixtures/project/de_project/NEXT_STEPS.md
+++ b/tests/fixtures/project/de_project/NEXT_STEPS.md
@@ -1,0 +1,28 @@
+# Next Steps
+
+Complete the following setup to enable automated decision environment builds.
+
+## Optional Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `REGISTRY_PASSWORD` | Container registry password (defaults to `GITHUB_TOKEN`) |
+| `REDHAT_REGISTRY_PASSWORD` | Red Hat registry password (for pulling base images) |
+
+## Repository Variables
+
+Configure these in **Settings > Secrets and variables > Actions > Variables**.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `REGISTRY_USERNAME` | `github.actor` | Username for the container registry where the built image will be pushed (defaults to `github.actor`) |
+| `EE_REGISTRY` | `ghcr.io` | Container registry hostname |
+| `EE_IMAGE_NAME` | `<owner>/<repo>` | Image name |
+| `REDHAT_REGISTRY_USERNAME` | - | Red Hat registry username |
+
+## Verify Your Setup
+
+1. Review the optional secrets listed above and configure any you need
+2. Push to a branch or open a pull request to trigger the workflow
+3. Check the workflow run in **Actions** for any authentication errors
+4. Once the build succeeds, verify the image in your container registry

--- a/tests/fixtures/project/de_project/NEXT_STEPS.md
+++ b/tests/fixtures/project/de_project/NEXT_STEPS.md
@@ -23,6 +23,6 @@ Configure these in **Settings > Secrets and variables > Actions > Variables**.
 ## Verify Your Setup
 
 1. Review the optional secrets listed above and configure any you need
-2. Push to a branch or open a pull request to trigger the workflow
+2. Publish a release, or run the workflow manually from **Actions > Run workflow**, to trigger a build
 3. Check the workflow run in **Actions** for any authentication errors
 4. Once the build succeeds, verify the image in your container registry

--- a/tests/fixtures/project/de_project/README.md
+++ b/tests/fixtures/project/de_project/README.md
@@ -1,0 +1,91 @@
+# Decision Environment Project
+
+This is a sample decision environment project for Event-Driven Ansible (EDA).
+
+Decision environments package the dependencies needed to run ansible-rulebook,
+including collections, Python packages, and system libraries.
+
+## Directory Structure
+
+```shell
+├── .github
+│   └── workflows
+│       └── ee-build.yml    # CI/CD workflow for building and publishing
+├── .gitignore
+├── README.md
+└── execution-environment.yml
+```
+
+## CI/CD Workflow Features
+
+The included GitHub Actions workflow (`ee-build.yml`) provides:
+
+### Token Validation
+
+- Validates configured tokens before starting builds
+- Fails fast if credentials are missing
+
+### Base Image Lifecycle Checks
+
+- Warns if the base image is older than 40 days
+- Fails if the base image is older than 80 days
+- Helps ensure your DE stays up-to-date with security patches
+
+### Production Release Workflow
+
+- Automatic tagging on release
+- Preserves previous production image as `previous` tag for rollback
+- Supports semantic versioning
+
+## Required Secrets and Variables
+
+### Secrets (Repository Settings > Secrets)
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `REGISTRY_USERNAME` | No | Container registry username (defaults to `github.actor`) |
+| `REGISTRY_PASSWORD` | No | Container registry password (defaults to `GITHUB_TOKEN`) |
+| `REDHAT_REGISTRY_PASSWORD` | No | Red Hat registry password (for pulling base images) |
+
+### Variables (Repository Settings > Variables)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EE_REGISTRY` | `ghcr.io` | Container registry hostname |
+| `EE_IMAGE_NAME` | `<owner>/<repo>` | Image name (GHCR requires the `owner/repo` namespace) |
+| `REDHAT_REGISTRY_USERNAME` | - | Red Hat registry username |
+
+## Usage
+
+### Building Locally
+
+```bash
+# Install ansible-builder
+pip install ansible-builder
+
+# Create build context
+ansible-builder create --file execution-environment.yml
+
+# Build the image
+podman build -t my-de:latest context/
+```
+
+### Triggering CI/CD
+
+- **Pull Request**: Builds and tests the DE (no push to registry)
+- **Push to main**: Builds, tests, and pushes with `latest` and commit SHA tags
+- **Release**: Tags image with version number and `prd` tag
+
+## Customization
+
+Edit `execution-environment.yml` to customize:
+
+- Base image
+- Ansible collections (e.g. `ansible.eda`)
+- Python dependencies (e.g. `ansible-rulebook`)
+- System packages (e.g. `java-17-openjdk-headless`)
+
+See the [ansible-builder documentation](https://ansible.readthedocs.io/projects/builder/en/latest/)
+for more details on execution environment configuration, and the
+[Event-Driven Ansible documentation](https://ansible.readthedocs.io/projects/rulebook/en/latest/)
+for decision environment guidance.

--- a/tests/fixtures/project/de_project/README.md
+++ b/tests/fixtures/project/de_project/README.md
@@ -21,6 +21,10 @@ including collections, Python packages, and system libraries.
 
 The included GitHub Actions workflow (`ee-build.yml`) provides:
 
+> **Note:** The workflow is named "Execution Environment Build" because decision
+> environments reuse the shared, ansible-builder-based EE build pipeline. The name
+> is cosmetic — the workflow builds your decision environment correctly.
+
 ### Token Validation
 
 - Validates configured tokens before starting builds

--- a/tests/fixtures/project/de_project/README.md
+++ b/tests/fixtures/project/de_project/README.md
@@ -12,6 +12,7 @@ including collections, Python packages, and system libraries.
 │   └── workflows
 │       └── ee-build.yml    # CI/CD workflow for building and publishing
 ├── .gitignore
+├── NEXT_STEPS.md
 ├── README.md
 └── execution-environment.yml
 ```
@@ -28,7 +29,8 @@ The included GitHub Actions workflow (`ee-build.yml`) provides:
 ### Base Image Lifecycle Checks
 
 - Warns if the base image is older than 40 days
-- Fails if the base image is older than 80 days
+- Warns more prominently if the base image is older than 80 days
+- Annotations only — the age check never blocks the build
 - Helps ensure your DE stays up-to-date with security patches
 
 ### Production Release Workflow
@@ -72,9 +74,8 @@ podman build -t my-de:latest context/
 
 ### Triggering CI/CD
 
-- **Pull Request**: Builds and tests the DE (no push to registry)
-- **Push to main**: Builds, tests, and pushes with `latest` and commit SHA tags
-- **Release**: Tags image with version number and `prd` tag
+- **Release (published)**: Builds the DE and tags the image with the release version and `prd` tag
+- **Manual dispatch** (Actions > Run workflow): Builds the DE on demand
 
 ## Customization
 

--- a/tests/fixtures/project/de_project/execution-environment.yml
+++ b/tests/fixtures/project/de_project/execution-environment.yml
@@ -1,0 +1,25 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-25/de-supported-rhel9:latest
+
+dependencies:
+  python_interpreter:
+    python_path: /usr/bin/python3.12
+
+  system:
+    - java-17-openjdk-headless [platform:rpm]
+
+  python:
+    - ansible-rulebook
+
+  galaxy:
+    collections:
+      - name: ansible.eda
+
+options:
+  package_manager_path: /usr/bin/microdnf
+  tags:
+    - ansible_sample_de

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -149,6 +149,25 @@ def test_run_init_ee(cli: CliRunCallable, tmp_path: Path) -> None:
     assert r"Note: execution_env project created at" in result.stdout
 
 
+def test_run_init_de(cli: CliRunCallable, tmp_path: Path) -> None:
+    """Test running ansible-creator init for decision_environment.
+
+    Args:
+        cli: cli_run function.
+        tmp_path: Temporary path.
+    """
+    final_dest = f"{tmp_path}/de_project"
+    cli(f"mkdir -p {final_dest}")
+
+    result = cli(
+        f"{CREATOR_BIN} init decision_environment {final_dest}",
+    )
+    assert result.returncode == 0
+
+    # check stdout
+    assert r"Note: decision_environment project created at" in result.stdout
+
+
 def test_run_init_collection_include(cli: CliRunCallable, tmp_path: Path) -> None:
     """Test init collection with --include to cherry-pick bundles.
 

--- a/tests/units/test_init_ee.py
+++ b/tests/units/test_init_ee.py
@@ -2150,3 +2150,112 @@ def test_ee_project_with_scm_servers_gitlab(
     ns = next_steps.read_text()
     assert "CI/CD" in ns
     assert "Actions" not in ns
+
+
+def test_run_success_de_project(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    cli_args: ConfigDict,
+) -> None:
+    """Init decision_environment applies DE defaults (base image, deps, collections).
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        cli_args: Dictionary, partial Init class object.
+    """
+    cli_args["project"] = "decision_environment"
+    cli_args["init_path"] = str(tmp_path / "de_project")
+    init = Init(Config(**cli_args))
+
+    init.run()
+    result = capsys.readouterr().out
+
+    assert r"Note: decision_environment project created" in result
+
+    cmp = dircmp(
+        str(tmp_path / "de_project"),
+        str(FIXTURES_DIR / "project" / "de_project"),
+    )
+    diff = has_differences(dcmp=cmp, errors=[])
+    assert not diff, diff
+
+
+def test_de_project_cli_override(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    output: Output,
+) -> None:
+    """CLI flags override DE defaults when init decision_environment.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        output: Output object for logging.
+    """
+    dest = tmp_path / "de_override"
+    config = Config(
+        creator_version="0.0.1",
+        output=output,
+        subcommand="init",
+        project="decision_environment",
+        init_path=str(dest),
+        base_image="my-custom-de:latest",
+        ee_name="custom_de",
+        scm_provider="github",
+    )
+    Init(config=config).run()
+    result = capsys.readouterr().out
+
+    assert r"Note: decision_environment project created" in result
+
+    ee_yml = dest / "execution-environment.yml"
+    content = ee_yml.read_text()
+    assert "my-custom-de:latest" in content
+    assert "custom_de" in content
+    assert "ansible-rulebook" in content
+    assert "ansible.eda" in content
+
+
+def test_de_project_with_config_file(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    output: Output,
+) -> None:
+    """Config file takes full precedence over DE defaults.
+
+    Args:
+        capsys: Pytest fixture to capture stdout and stderr.
+        tmp_path: Temporary directory path.
+        output: Output object for logging.
+    """
+    config_data = {
+        "base_image": "custom-from-file:latest",
+        "ee_name": "file_de",
+        "collections": [{"name": "ansible.netcommon"}],
+    }
+    config_path = tmp_path / "de-config.json"
+    config_path.write_text(json.dumps(config_data))
+
+    dest = tmp_path / "de_from_file"
+    config = Config(
+        creator_version="0.0.1",
+        output=output,
+        subcommand="init",
+        project="decision_environment",
+        init_path=str(dest),
+        ee_config_file=str(config_path),
+        scm_provider="github",
+    )
+    Init(config=config).run()
+    result = capsys.readouterr().out
+
+    assert r"Note: decision_environment project created" in result
+
+    ee_yml = dest / "execution-environment.yml"
+    content = ee_yml.read_text()
+    assert "custom-from-file:latest" in content
+    assert "file_de" in content
+    assert "ansible.netcommon" in content
+    assert "ansible-rulebook" not in content
+    assert "ansible.eda" not in content


### PR DESCRIPTION
## Summary

Addresses architect feedback from @cidrblock on #624: decision environments should be a
first-class `init` project type, not a flag on `execution_env`.

**Before:** `ansible-creator init execution_env --ee-type decision_environment <path>`
**After:** `ansible-creator init decision_environment <path>`

### What changed

- **CLI**: `decision_environment` is now its own subcommand under `init`, alongside
  `collection`, `playbook`, and `execution_env`
- **Shared build flags**: Extracted `_add_ee_build_args()` so both `execution_env` and
  `decision_environment` reuse the same `--ee-config`, `--ee-base-image`, etc. flags
  without duplication
- **DE defaults**: When no `--ee-config`/`--ee-config-file` is provided, DE projects
  automatically use `de-supported-rhel9` base image, `ansible-rulebook`,
  `java-17-openjdk-headless`, and `ansible.eda` collection
- **Templates**: New `decision_environment_project/` template directory with DE-specific
  README and NEXT_STEPS referencing EDA documentation
- **Image detection**: `OFFICIAL_DE_IMAGES` separated from `OFFICIAL_EE_IMAGES`, combined
  in `ALL_OFFICIAL_IMAGES` for Python path and package manager detection
- **Success messaging**: Now correctly reports `"decision_environment project created"`

### Brad's feedback items addressed

| Concern | Resolution |
|---------|-----------|
| DE hard to discover in help | `decision_environment` appears directly in `ansible-creator init --help` |
| Success message says "execution_env" for DE | Message now says `"decision_environment project created"` |
| Help text overloads "type of execution environment" | No `--ee-type` flag; DE is its own project type |
| DE images in OFFICIAL_EE_IMAGES | Separated into `OFFICIAL_DE_IMAGES` |

## Test plan

- [x] Unit test: DE project scaffold with default DE dependencies (fixture comparison)
- [x] Unit test: CLI flag overrides on DE project
- [x] Unit test: `--ee-config-file` takes precedence over DE defaults
- [x] Integration test: `ansible-creator init decision_environment <path>` end-to-end
- [x] All 279 existing tests pass (no regressions)
- [x] Pylint 10/10, ruff clean, mypy clean, pydoclint clean

Supersedes #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support for initializing Decision Environment projects.
  * Added configurable defaults for base images, dependencies, collections, build options, and image naming.
  * Added templates for building and publishing images through GitHub and GitLab CI/CD.
* **Documentation**
  * Added comprehensive README and next-steps guidance for local builds, configuration, publishing, and verification.
* **Bug Fixes**
  * Improved help text, project-type handling, configuration precedence, and official image recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->